### PR TITLE
[OFFSEASON] Multi-season data refactor and offseason migration cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ GET    /champion/history
 GET    /gameid
 GET    /check-status
 GET    /season/meta
+GET    /season/options
 
 GET    /draft/state
 PATCH  /draft/state
@@ -246,9 +247,11 @@ Notes:
 
 ### Key DynamoDB tables
 
-- `Players` (player profiles, teams, title defenses, etc.)
-- `GameRecords` (per-game win/loss records)
-- `GameOptions` (current champion + draft state)
+- `PlayerLifetime` (lifetime `championships` + `totalDefenses`)
+- `PlayerSeason` (season-specific teams + `titleDefenses`)
+- `GameRecordsV2` (season-scoped game history by `seasonId`)
+- `DraftState` (season-scoped draft state by `draftId=seasonId`)
+- `GameOptions` (current champion/checker state + `seasonCatalog`)
 - `SocketConnections` (WebSocket connections for live updates)
 
 ### Lambda config env vars
@@ -257,22 +260,18 @@ Used by `lambdas/http-api/index.js`:
 
 ```
 AWS_REGION
-PLAYERS_TABLE
-GAME_RECORDS_TABLE
 GAME_OPTIONS_TABLE
-DRAFT_STATE_ID
+PLAYER_SEASON_TABLE
+PLAYER_LIFETIME_TABLE
+GAME_RECORDS_V2_TABLE
+DRAFT_STATE_TABLE
 CORS_ORIGIN
 NHL_API_BASE
 NHL_TEAMS
 DEFAULT_SEASON
+SEASON_CATALOG_ID
+AVAILABLE_SEASONS
 ADMIN_API_TOKEN
-PLAYERS_TABLE_SEASON1
-GAME_RECORDS_TABLE_SEASON1
-PLAYERS_TABLE_SEASON2
-GAME_RECORDS_TABLE_SEASON2
-PLAYERS_TABLE_SEASON3
-GAME_RECORDS_TABLE_SEASON3
-...
 SEASON2_REGULAR_SEASON_END
 SEASON2_PLAYOFFS_START
 SEASON2_SEASON_OVER
@@ -296,8 +295,10 @@ LAST_CHECKED_AT_FIELD
 FINALIZED_AT_FIELD
 WATCH_STARTED_AT_FIELD
 PROCESSED_GAME_ID_FIELD
-PLAYERS_TABLE
-GAME_RECORDS_TABLE
+PLAYER_SEASON_TABLE
+PLAYER_LIFETIME_TABLE
+GAME_RECORDS_V2_TABLE
+DEFAULT_SEASON
 NHL_API_BASE
 SELF_SCHEDULING_ENABLED
 SCHEDULER_GROUP_NAME
@@ -321,9 +322,10 @@ Purpose:
   - Schedules an adaptive one-off recheck (10m pregame, 2m live, 1m critical).
 - If game is final:
   - Claims `processedGameId` to prevent duplicate write cycles.
-  - Writes a game record to `GameRecords`.
+  - Writes a game record to `GameRecordsV2` using `seasonId + gameId`.
   - Updates `champion` in `GameOptions`.
-  - Increments `titleDefenses` and `totalDefenses` for the winning player.
+  - Increments season `titleDefenses` in `PlayerSeason`.
+  - Increments lifetime `totalDefenses` in `PlayerLifetime`.
   - Marks finalization metadata and clears active game fields.
   - Invalidates API cache paths (for example `/champion`, `/gameid`) in CloudFront.
   - Stops additional self-check schedules.
@@ -355,6 +357,14 @@ Optional broadcaster:
     - `Handler error`
     - `decision":"watching_too_long"`
   - Creates matching CloudWatch alarms in namespace `InSeason/Checker`.
+
+## Offseason migration helper
+
+- `scripts/aws/offseason-migrate-season-data.sh`
+  - Snapshots legacy season tables.
+  - Backfills `PlayerLifetime`, `PlayerSeason`, `GameRecordsV2`, and `DraftState`.
+  - Optionally updates Lambda env vars for API/checker cutover.
+  - Tags legacy tables as frozen after migration.
 
 ## NHL API usage
 

--- a/ai/project/offseason-multi-season-refactor/BACKLOG.md
+++ b/ai/project/offseason-multi-season-refactor/BACKLOG.md
@@ -1,0 +1,25 @@
+# BACKLOG: offseason-multi-season-refactor
+
+## Status legend
+- `TODO`
+- `IN_PROGRESS`
+- `BLOCKED`
+- `DONE`
+
+## Tasks
+| ID | Status | Task | Owner | Verification |
+|---|---|---|---|---|
+| 1 | DONE | Create branch from `main` and include in-season draft write lock commit | AI | `git log` includes cherry-pick `1b006e9` |
+| 2 | DONE | Cut over HTTP API to multi-season tables + add `/season/options` | AI | `lambdas/http-api/index.js` |
+| 3 | DONE | Update frontend season option bootstrap and draft route gating | AI | `src/main.js`, `src/store/seasonStore.js`, `src/router/index.js` |
+| 4 | DONE | Cut over checker Lambda writes to season/lifetime split tables | AI | `lambdas/check-game/index.js` |
+| 5 | DONE | Add offseason one-time migration script | AI | `scripts/aws/offseason-migrate-season-data.sh` |
+| 6 | DONE | Update runbook + README for migration/cutover model | AI | `docs/season-data-runbook.md`, `README.md` |
+| 7 | DONE | Update unit tests for new API table model and run verification | AI | `tests/unit/httpApi.spec.js`, `npm run test:unit`, `npm run lint` |
+| 8 | TODO | Open Draft MR with `[OFFSEASON]` prefix + `offseason` label + merge gate checklist | AI | GitHub MR link |
+
+## Notes
+- Merge gate:
+  - `GET /season/meta?season=season2` returns `seasonOver=true`
+  - Date on/after April 17, 2026
+  - Pre-draft window confirmed by operator

--- a/ai/project/offseason-multi-season-refactor/BACKLOG.md
+++ b/ai/project/offseason-multi-season-refactor/BACKLOG.md
@@ -16,7 +16,7 @@
 | 5 | DONE | Add offseason one-time migration script | AI | `scripts/aws/offseason-migrate-season-data.sh` |
 | 6 | DONE | Update runbook + README for migration/cutover model | AI | `docs/season-data-runbook.md`, `README.md` |
 | 7 | DONE | Update unit tests for new API table model and run verification | AI | `tests/unit/httpApi.spec.js`, `npm run test:unit`, `npm run lint` |
-| 8 | TODO | Open Draft MR with `[OFFSEASON]` prefix + `offseason` label + merge gate checklist | AI | GitHub MR link |
+| 8 | DONE | Open Draft MR with `[OFFSEASON]` prefix + `offseason` label + merge gate checklist | AI | https://github.com/ryandeshon/in-season-stanley-cup/pull/51 |
 
 ## Notes
 - Merge gate:

--- a/ai/project/offseason-multi-season-refactor/SPEC.md
+++ b/ai/project/offseason-multi-season-refactor/SPEC.md
@@ -1,0 +1,64 @@
+# SPEC: offseason-multi-season-refactor
+
+## Summary
+Implement an offseason-only big-bang refactor from legacy per-season tables to a single multi-season data model, then prepare deployment/migration runbooks and safeguards for post-season rollout.
+
+## Problem
+- Legacy data model relies on separate season tables and manual season copy operations.
+- Draft and game record handling are not consistently season-scoped across all backend paths.
+- Frontend season selector is partially hardcoded.
+- No one-shot migration tool exists for offseason cutover.
+
+## Goals
+- Move API and checker Lambda to:
+  - `PlayerLifetime`
+  - `PlayerSeason`
+  - `GameRecordsV2`
+  - `DraftState` (scoped by `draftId=seasonId`)
+- Keep player stat semantics locked:
+  - `championships` lifetime carry-over
+  - `totalDefenses` lifetime carry-over
+  - `titleDefenses` season-only reset
+- Add season catalog endpoint-driven season options (`GET /season/options`).
+- Add one-time migration script + runbook for offseason execution.
+- Keep draft/team in-season mutation lock behavior active.
+
+## Non-Goals
+- In-season production rollout.
+- Season branding/theme redesign beyond existing season1/season2 presentation.
+
+## Constraints
+- Merge only in offseason window with explicit gates.
+- Preserve current frontend response shapes for `GET /players`, `GET /game-records`, and champion history.
+- Migration must be idempotent enough for safe reruns during validation.
+
+## Technical Design
+- Backend `lambdas/http-api/index.js` reads/writes only new tables and merges season+lifetime rows for player responses.
+- Backend `lambdas/check-game/index.js` writes finalized game records to `GameRecordsV2` and increments defenses in both season + lifetime tables.
+- Frontend bootstraps season options via API; draft route access is gated by season metadata + completion state.
+- Migration script snapshots legacy tables, backfills new tables, and optionally updates Lambda env vars for cutover.
+
+## Risks and Mitigations
+- Risk: data mismatch during migration.
+  - Mitigation: pre-snapshot + parity checks + rollback path.
+- Risk: accidental in-season draft mutations.
+  - Mitigation: existing write-lock guard retained.
+- Risk: contract drift between frontend and deployed API.
+  - Mitigation: route/CORS verification checklist in runbook.
+
+## Acceptance Criteria
+1. API serves season data from new tables only.
+2. Checker writes game outcomes to season-scoped game records and defense counters split by season/lifetime semantics.
+3. Frontend season selector is API-driven from `GET /season/options`.
+4. Draft routes are offseason-gated with read-only completed snapshot support during active season.
+5. Migration script + runbook fully document offseason cutover, validation, and rollback.
+
+## Verification Plan
+- `npm run test:unit`
+- `npm run lint`
+- Manual migration dry run in AWS account with snapshot validation.
+
+## Rollback Plan
+- Restore legacy snapshots to original tables.
+- Revert Lambda env vars to legacy table config.
+- Redeploy previous Lambda package if cutover regression appears.

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -13,6 +13,14 @@ Cypress.Commands.add('mockApiScenario', (fixtureName = 'cup-day-multiple-games')
         playoffsStart: null,
       },
       seasonMetaStatus = 200,
+      seasonOptionsResponse = {
+        defaultSeason: 'season2',
+        seasons: [
+          { id: 'season1', label: '1' },
+          { id: 'season2', label: '2' },
+        ],
+      },
+      seasonOptionsStatus = 200,
       championHistoryResponse = {
         seasonId: 'season2',
         limit: 6,
@@ -26,6 +34,11 @@ Cypress.Commands.add('mockApiScenario', (fixtureName = 'cup-day-multiple-games')
       scheduleResponse = { gameWeek: [] },
       scheduleStatus = 200,
     } = data;
+
+    cy.intercept('GET', '**/season/options*', {
+      statusCode: seasonOptionsStatus,
+      body: seasonOptionsResponse,
+    }).as('getSeasonOptions');
 
     cy.intercept('GET', '**/champion*', {
       statusCode: championStatus,
@@ -105,6 +118,32 @@ Cypress.Commands.add('mockDraftScenario', (fixtureName = 'draft-default') => {
       availableTeams: [],
       version: 0,
     };
+
+    const seasonMetaResponse = data.seasonMetaResponse || {
+      seasonId: 'season2',
+      seasonOver: true,
+      regularSeasonEnd: null,
+      playoffsStart: null,
+    };
+    const seasonMetaStatus = data.seasonMetaStatus || 200;
+    const seasonOptionsResponse = data.seasonOptionsResponse || {
+      defaultSeason: 'season2',
+      seasons: [
+        { id: 'season1', label: '1' },
+        { id: 'season2', label: '2' },
+      ],
+    };
+    const seasonOptionsStatus = data.seasonOptionsStatus || 200;
+
+    cy.intercept('GET', '**/season/options*', {
+      statusCode: seasonOptionsStatus,
+      body: seasonOptionsResponse,
+    }).as('getSeasonOptions');
+
+    cy.intercept('GET', '**/season/meta*', {
+      statusCode: seasonMetaStatus,
+      body: seasonMetaResponse,
+    }).as('getSeasonMeta');
 
     cy.intercept('GET', '**/players*', {
       statusCode: 200,

--- a/docs/season-data-runbook.md
+++ b/docs/season-data-runbook.md
@@ -1,15 +1,43 @@
 # Season Data Runbook
 
-## Current backend behavior
-- The HTTP API accepts `?season=seasonN` (or `?season=N`) on data endpoints.
-- If `season` is omitted, the API uses `DEFAULT_SEASON` (fallback: `season2`).
-- Table resolution rules in `lambdas/http-api/index.js`:
-  - `season2` uses `PLAYERS_TABLE` and `GAME_RECORDS_TABLE`.
-  - `seasonN` (`N != 2`) uses:
-    - `PLAYERS_TABLE_SEASONN` / `GAME_RECORDS_TABLE_SEASONN` when provided.
-    - Otherwise defaults to `<PLAYERS_TABLE>-SeasonN` and `<GAME_RECORDS_TABLE>-SeasonN`.
+## Offseason merge gate (required)
+Merge the offseason refactor only when all checks pass:
 
-## Supported season-aware endpoints
+1. `GET /season/meta?season=season2` returns `seasonOver=true`
+2. Date is on/after **April 17, 2026**
+3. Operator confirms pre-draft offseason window
+
+## Target data model (single multi-season structure)
+
+- `PlayerLifetime`
+  - Partition key: `playerId`
+  - Fields: `name`, `championships`, `totalDefenses`, timestamps
+  - Carry-over fields: `championships`, `totalDefenses`
+- `PlayerSeason`
+  - Partition key: `seasonId`
+  - Sort key: `playerId`
+  - Fields: `name`, `teams`, `titleDefenses`, timestamps
+  - Season-only field: `titleDefenses` (reset to `0` each new season)
+- `GameRecordsV2`
+  - Partition key: `seasonId`
+  - Sort key: `gameId`
+  - Fields: historical winner/loser data per game
+- `DraftState`
+  - Partition key: `draftId`
+  - Rule: `draftId = seasonId`
+- `GameOptions`
+  - Keeps champion/checker state
+  - Holds `seasonCatalog` item for `GET /season/options`
+
+## Season-aware API behavior
+
+- `?season=seasonN` (or `?season=N`) is accepted.
+- Omitted `season` uses `DEFAULT_SEASON` (fallback: `season2`).
+- Backend uses only the new tables (`PlayerSeason`, `PlayerLifetime`, `GameRecordsV2`, `DraftState`).
+
+### Endpoints
+- `GET /season/options`
+- `GET /season/meta`
 - `GET /players`
 - `GET /players/:name`
 - `POST /players/reset-teams`
@@ -19,92 +47,123 @@
 - `GET /champion`
 - `GET /gameid`
 - `GET /check-status`
-- `GET /season/meta`
 - `GET /draft/state`
 - `PATCH /draft/state`
 - `POST /draft/select-team`
 
-## Draft write lock (active season protection)
-- Draft/team mutation routes are blocked during active season:
-  - `POST /players/reset-teams`
-  - `PATCH /players/:id/teams`
-  - `PATCH /draft/state`
-  - `POST /draft/select-team`
-- Allowed windows:
-  - Pre-season (no game records yet for the selected season), or
-  - Off-season (`seasonOver=true` from season metadata).
-- In-season writes return `409` with a lock message.
-- Emergency override (operators only): set `ALLOW_IN_SEASON_DRAFT_WRITES=true` on `inseason-http-api`.
+## Draft/team write lock policy
+
+Mutating draft/team routes are blocked during active season (`409`), unless:
+
+- season is over (`seasonOver=true`), or
+- pre-season with no game records, or
+- emergency override is set: `ALLOW_IN_SEASON_DRAFT_WRITES=true`
+
+Protected routes:
+- `POST /players/reset-teams`
+- `PATCH /players/:id/teams`
+- `PATCH /draft/state`
+- `POST /draft/select-team`
 
 ## Contract deployment verification checklist
-Use this checklist any time frontend code depends on new HTTP API routes (for example PR #48 season contracts).
 
-1. Verify routes exist on the target API/stage:
-   - `GET /season/meta`
-   - `GET /champion/history`
-2. Verify CORS from local-dev origin:
-   - `curl -i -H 'Origin: http://localhost:8080' 'https://<api-id>.execute-api.us-east-1.amazonaws.com/<stage>/season/meta?season=season2'`
-   - `curl -i -H 'Origin: http://localhost:8080' 'https://<api-id>.execute-api.us-east-1.amazonaws.com/<stage>/champion/history?season=season2&limit=6'`
-3. Pass criteria:
-   - Non-`404` status on both endpoints.
-   - Response includes `access-control-allow-origin` for browser requests.
-4. Run post-deploy smoke tests:
-   - `GET /champion?season=season2`
-   - `GET /season/meta?season=season2`
-   - `GET /champion/history?season=season2&limit=6`
+Use this checklist any time frontend relies on API contracts:
 
-### Troubleshooting: Browser CORS error + endpoint 404
-If you see browser errors like:
-- `blocked by CORS policy: No 'Access-Control-Allow-Origin' header`
-- paired with failed requests to `/season/meta` or `/champion/history`
+1. Route existence checks:
+- `GET /season/meta`
+- `GET /champion/history`
+- `GET /season/options`
 
-Then check the same endpoint with `curl -i` first. A `404` response from API Gateway without CORS headers means the route is missing or not deployed on that stage yet. Fix route/deployment first; frontend fallback should stay non-blocking locally, but production should not rely on fallback.
-
-## New season rollover checklist
-1. Pick the season ID you will use (example: `season3`).
-2. Create season tables (or decide to keep shared tables and add `seasonId` attributes).
-3. Configure Lambda env vars for the new season tables and metadata:
-   - `DEFAULT_SEASON=season3`
-   - `PLAYERS_TABLE_SEASON3=<players-table-name>`
-   - `GAME_RECORDS_TABLE_SEASON3=<game-records-table-name>`
-   - `SEASON3_REGULAR_SEASON_END=<YYYY-MM-DD>`
-   - `SEASON3_PLAYOFFS_START=<YYYY-MM-DD>`
-   - Optional: `SEASON3_SEASON_OVER=true|false`
-4. Deploy `lambdas/http-api/index.js` with the updated env vars.
-5. Verify:
-   - `GET /season/meta?season=season3`
-   - `GET /players?season=season3`
-   - `GET /game-records?season=season3`
-6. If using Draft in the new season, initialize draft state by calling `GET /draft/state?season=season3` once.
-
-## AWS CLI snippets
+2. CORS checks from local origin:
 ```bash
-# Read current Lambda env so you can merge instead of overwriting blindly.
-aws lambda get-function-configuration \
-  --function-name inseason-http-api \
-  --query 'Environment.Variables'
+curl -i -H 'Origin: http://localhost:8080' \
+  'https://<api-id>.execute-api.us-east-1.amazonaws.com/<stage>/season/meta?season=season2'
 
-# Example update (replace placeholders and include your existing variables).
-aws lambda update-function-configuration \
-  --function-name inseason-http-api \
-  --environment 'Variables={
-    AWS_REGION=us-east-1,
-    PLAYERS_TABLE=Players,
-    GAME_RECORDS_TABLE=GameRecords,
-    GAME_OPTIONS_TABLE=GameOptions,
-    DEFAULT_SEASON=season3,
-    PLAYERS_TABLE_SEASON3=Players-Season3,
-    GAME_RECORDS_TABLE_SEASON3=GameRecords-Season3,
-    SEASON3_REGULAR_SEASON_END=2027-04-15,
-    SEASON3_PLAYOFFS_START=2027-04-18
-  }'
+curl -i -H 'Origin: http://localhost:8080' \
+  'https://<api-id>.execute-api.us-east-1.amazonaws.com/<stage>/champion/history?season=season2&limit=6'
+
+curl -i -H 'Origin: http://localhost:8080' \
+  'https://<api-id>.execute-api.us-east-1.amazonaws.com/<stage>/season/options'
 ```
 
-## Recommended future improvement (single-table accumulation)
-If you want seasons to accumulate without yearly table cloning:
-1. Add `seasonId` to `Players` and `GameRecords`.
-2. Add GSIs keyed by `seasonId` for query efficiency.
-3. Keep one table per entity and query by `seasonId` instead of per-season table names.
-4. Backfill historical records with `seasonId` values.
+3. Pass criteria:
+- non-`404` status
+- `access-control-allow-origin` present for browser requests
 
-This removes annual table-copy work and keeps season transitions operationally lighter.
+4. Post-deploy smoke tests:
+- `GET /players?season=season2`
+- `GET /game-records?season=season2`
+- `GET /draft/state?season=season2`
+
+### Troubleshooting signature: CORS + 404
+If browser shows:
+- `No 'Access-Control-Allow-Origin' header`
+- and the same URL is `404` in network logs,
+
+the route is missing/not deployed on that stage. Fix deployment first.
+
+## One-time offseason migration command
+
+Script:
+- `scripts/aws/offseason-migrate-season-data.sh`
+
+What it does:
+- snapshots legacy tables,
+- creates new tables if missing,
+- backfills `PlayerLifetime`, `PlayerSeason`, `GameRecordsV2`, `DraftState`,
+- upserts `seasonCatalog` in `GameOptions`,
+- optionally updates Lambda env vars for cutover,
+- tags legacy tables as `migrationStatus=legacy-frozen`.
+
+### Example run (dry-safe default)
+```bash
+AWS_REGION=us-east-1 \
+AWS_PROFILE=inseason-admin \
+CURRENT_SEASON_ID=season2 \
+SEASON1_ID=season1 \
+bash scripts/aws/offseason-migrate-season-data.sh
+```
+
+### Apply Lambda env cutover in same run
+```bash
+AWS_REGION=us-east-1 \
+AWS_PROFILE=inseason-admin \
+APPLY_LAMBDA_ENV_CUTOVER=true \
+HTTP_API_FUNCTION_NAME=inseason-http-api \
+CHECK_GAME_FUNCTION_NAME=inseason-check-game \
+bash scripts/aws/offseason-migrate-season-data.sh
+```
+
+### Key env vars written during cutover
+- `PLAYER_SEASON_TABLE`
+- `PLAYER_LIFETIME_TABLE`
+- `GAME_RECORDS_V2_TABLE`
+- `DRAFT_STATE_TABLE`
+- `DEFAULT_SEASON`
+- `SEASON_CATALOG_ID`
+
+## Post-migration validation
+
+1. Lifetime parity:
+- For each player, `championships` and `totalDefenses` match pre-migration values.
+
+2. Season parity:
+- Per season, `teams` and `titleDefenses` match source tables.
+
+3. API parity:
+- Validate:
+  - `GET /players`
+  - `GET /players/:name`
+  - `GET /game-records`
+  - `GET /champion/history`
+
+4. Draft safety:
+- In-season mutations return `409`.
+- Draft state reads/writes are isolated by `draftId=seasonId`.
+
+## Rollback
+
+1. Restore from snapshot JSONs in `tmp/season-data-migration/<timestamp>/`.
+2. Revert Lambda env vars to legacy table variables.
+3. Redeploy previous Lambda package if needed.
+4. Keep legacy tables until rollback confidence window ends.

--- a/docs/season-data-runbook.md
+++ b/docs/season-data-runbook.md
@@ -24,6 +24,18 @@
 - `PATCH /draft/state`
 - `POST /draft/select-team`
 
+## Draft write lock (active season protection)
+- Draft/team mutation routes are blocked during active season:
+  - `POST /players/reset-teams`
+  - `PATCH /players/:id/teams`
+  - `PATCH /draft/state`
+  - `POST /draft/select-team`
+- Allowed windows:
+  - Pre-season (no game records yet for the selected season), or
+  - Off-season (`seasonOver=true` from season metadata).
+- In-season writes return `409` with a lock message.
+- Emergency override (operators only): set `ALLOW_IN_SEASON_DRAFT_WRITES=true` on `inseason-http-api`.
+
 ## Contract deployment verification checklist
 Use this checklist any time frontend code depends on new HTTP API routes (for example PR #48 season contracts).
 

--- a/lambdas/check-game/index.js
+++ b/lambdas/check-game/index.js
@@ -19,8 +19,9 @@ const scheduler = AWS.Scheduler
   : null;
 
 const TABLE_NAME = process.env.GAME_OPTIONS_TABLE || 'GameOptions';
-const PLAYERS_TABLE = process.env.PLAYERS_TABLE || 'Players';
-const GAME_RECORDS = process.env.GAME_RECORDS_TABLE || 'GameRecords';
+const PLAYER_SEASON_TABLE = process.env.PLAYER_SEASON_TABLE || 'PlayerSeason';
+const PLAYER_LIFETIME_TABLE = process.env.PLAYER_LIFETIME_TABLE || 'PlayerLifetime';
+const GAME_RECORDS_V2_TABLE = process.env.GAME_RECORDS_V2_TABLE || 'GameRecordsV2';
 const PARTITION_KEY = process.env.GAME_OPTIONS_KEY || 'currentChampion';
 const GAME_ID_FIELD = process.env.GAME_ID_FIELD || 'gameID';
 const ACTIVE_GAME_ID_FIELD = process.env.ACTIVE_GAME_ID_FIELD || 'activeGameId';
@@ -53,6 +54,30 @@ const API_CACHE_INVALIDATION_PATHS = (
   .map((path) => path.trim())
   .filter(Boolean)
   .map((path) => (path.startsWith('/') ? path : `/${path}`));
+const DEFAULT_SEASON = normalizeSeasonId(process.env.DEFAULT_SEASON) || 'season2';
+
+function normalizeSeasonId(value) {
+  if (!value) return null;
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return null;
+  const seasonMatch = normalized.match(/^season(\d+)$/);
+  if (seasonMatch) {
+    const number = Number(seasonMatch[1]);
+    if (Number.isInteger(number) && number > 0) {
+      return `season${number}`;
+    }
+    return null;
+  }
+  const numeric = Number(normalized);
+  if (Number.isInteger(numeric) && numeric > 0) {
+    return `season${numeric}`;
+  }
+  return null;
+}
+
+function resolveSeasonId(gameOptions = {}) {
+  return normalizeSeasonId(gameOptions.currentSeason) || DEFAULT_SEASON;
+}
 
 function log(level, msg, extra = {}) {
   const base = { level, ts: new Date().toISOString(), ...extra };
@@ -387,61 +412,145 @@ async function fetchGameData(gameID) {
   });
 }
 
-async function findPlayerWithTeam(team) {
-  const params = { TableName: PLAYERS_TABLE };
+async function listSeasonPlayers(seasonId) {
+  const players = [];
+  let ExclusiveStartKey;
+  do {
+    const result = await dynamoDB
+      .query({
+        TableName: PLAYER_SEASON_TABLE,
+        KeyConditionExpression: '#seasonId = :seasonId',
+        ExpressionAttributeNames: {
+          '#seasonId': 'seasonId',
+        },
+        ExpressionAttributeValues: {
+          ':seasonId': seasonId,
+        },
+        ...(ExclusiveStartKey ? { ExclusiveStartKey } : {}),
+      })
+      .promise();
+    players.push(...(result.Items || []));
+    ExclusiveStartKey = result.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+  return players;
+}
+
+async function findPlayerWithTeam(team, seasonId) {
   try {
-    const result = await dynamoDB.scan(params).promise();
-    const player = result.Items?.find(
-      (p) => Array.isArray(p.teams) && p.teams.includes(team)
+    const players = await listSeasonPlayers(seasonId);
+    const player = players.find(
+      (candidate) => Array.isArray(candidate.teams) && candidate.teams.includes(team)
     );
-    return player ? player.id : null;
+    if (!player) return null;
+    return {
+      playerId: player.playerId,
+      name: player.name || null,
+    };
   } catch (error) {
-    log('error', 'Players scan failed', { error: String(error) });
+    log('error', 'PlayerSeason query failed', {
+      error: String(error),
+      seasonId,
+      team,
+    });
     throw new Error('Failed to find player with winning team');
   }
 }
 
-async function incrementTitleDefense(playerId, team) {
-  const params = {
-    TableName: PLAYERS_TABLE,
-    Key: { id: playerId },
-    UpdateExpression:
-      'SET titleDefenses = if_not_exists(titleDefenses, :zero) + :inc, totalDefenses = if_not_exists(totalDefenses, :zero) + :inc',
-    ExpressionAttributeValues: { ':inc': 1, ':zero': 0 },
-    ReturnValues: 'UPDATED_NEW',
-  };
-  const out = await dynamoDB.update(params).promise();
+async function incrementDefenses(playerId, team, seasonId, playerName = null) {
+  const timestamp = nowIso();
+  const [seasonUpdate, lifetimeUpdate] = await Promise.all([
+    dynamoDB
+      .update({
+        TableName: PLAYER_SEASON_TABLE,
+        Key: { seasonId, playerId },
+        UpdateExpression:
+          'SET #name = if_not_exists(#name, :name), teams = if_not_exists(teams, :emptyTeams), titleDefenses = if_not_exists(titleDefenses, :zero) + :inc, updatedAt = :updatedAt',
+        ExpressionAttributeNames: {
+          '#name': 'name',
+        },
+        ExpressionAttributeValues: {
+          ':name': playerName || String(playerId),
+          ':emptyTeams': [],
+          ':inc': 1,
+          ':zero': 0,
+          ':updatedAt': timestamp,
+        },
+        ReturnValues: 'UPDATED_NEW',
+      })
+      .promise(),
+    dynamoDB
+      .update({
+        TableName: PLAYER_LIFETIME_TABLE,
+        Key: { playerId },
+        UpdateExpression:
+          'SET #name = if_not_exists(#name, :name), totalDefenses = if_not_exists(totalDefenses, :zero) + :inc, updatedAt = :updatedAt',
+        ExpressionAttributeNames: {
+          '#name': 'name',
+        },
+        ExpressionAttributeValues: {
+          ':name': playerName || String(playerId),
+          ':inc': 1,
+          ':zero': 0,
+          ':updatedAt': timestamp,
+        },
+        ReturnValues: 'UPDATED_NEW',
+      })
+      .promise(),
+  ]);
+
   log('info', 'Player defenses incremented', {
     playerId,
     team,
-    updated: out?.Attributes,
+    seasonId,
+    seasonUpdated: seasonUpdate?.Attributes,
+    lifetimeUpdated: lifetimeUpdate?.Attributes,
   });
 }
 
-async function saveGameStats(gameID, wTeam, wScore, lTeam, lScore) {
+async function saveGameStats(seasonId, gameID, wTeam, wScore, lTeam, lScore) {
+  const normalizedGameId = String(gameID);
+  const timestamp = nowIso();
   const params = {
-    TableName: GAME_RECORDS,
+    TableName: GAME_RECORDS_V2_TABLE,
     Item: {
-      id: gameID,
+      seasonId,
+      gameId: normalizedGameId,
+      id: normalizedGameId,
       wTeam,
       wScore,
       lTeam,
       lScore,
-      savedAt: new Date().toISOString(),
+      savedAt: timestamp,
+      updatedAt: timestamp,
     },
-    ConditionExpression: 'attribute_not_exists(id)',
+    ConditionExpression:
+      'attribute_not_exists(#seasonId) AND attribute_not_exists(#gameId)',
+    ExpressionAttributeNames: {
+      '#seasonId': 'seasonId',
+      '#gameId': 'gameId',
+    },
   };
 
   try {
     await dynamoDB.put(params).promise();
-    log('info', 'Game record saved', { gameID, wTeam, wScore, lTeam, lScore });
+    log('info', 'Game record saved', {
+      seasonId,
+      gameID: normalizedGameId,
+      wTeam,
+      wScore,
+      lTeam,
+      lScore,
+    });
     return true;
-  } catch (e) {
-    if (e.code === 'ConditionalCheckFailedException') {
-      log('info', 'Game record already exists, skipping save', { gameID });
+  } catch (error) {
+    if (error.code === 'ConditionalCheckFailedException') {
+      log('info', 'Game record already exists, skipping save', {
+        seasonId,
+        gameID: normalizedGameId,
+      });
       return false;
     }
-    throw e;
+    throw error;
   }
 }
 
@@ -610,6 +719,7 @@ const handler = async (event, context) => {
 
   try {
     const gameOptions = await getGameOptions();
+    const seasonId = resolveSeasonId(gameOptions);
     const champion = gameOptions?.[CHAMPION_FIELD] ?? null;
     if (!champion) {
       log('info', 'No champion set in GameOptions; exiting early');
@@ -645,7 +755,7 @@ const handler = async (event, context) => {
         decision: 'discovery_set_watch',
       });
     }
-    log('info', 'GameID loaded', { gameID });
+    log('info', 'GameID loaded', { gameID, seasonId });
 
     const game = await fetchGameData(gameID);
     log('info', 'Game state fetched', {
@@ -725,6 +835,7 @@ const handler = async (event, context) => {
 
     try {
       const didSaveGameRecord = await saveGameStats(
+        seasonId,
         gameID,
         wTeam,
         wScore,
@@ -736,15 +847,21 @@ const handler = async (event, context) => {
       await invalidateApiCache(gameID, 'game_finalized');
 
       if (didSaveGameRecord) {
-        const playerId = await findPlayerWithTeam(wTeam);
-        if (playerId) {
-          await incrementTitleDefense(playerId, wTeam);
+        const winnerPlayer = await findPlayerWithTeam(wTeam, seasonId);
+        if (winnerPlayer?.playerId !== undefined && winnerPlayer?.playerId !== null) {
+          await incrementDefenses(
+            winnerPlayer.playerId,
+            wTeam,
+            seasonId,
+            winnerPlayer.name
+          );
         } else {
-          log('info', 'No player found for winning team', { wTeam });
+          log('info', 'No player found for winning team', { wTeam, seasonId });
         }
       } else {
         log('info', 'Skipping defense increment due existing game record', {
           gameID,
+          seasonId,
           writeOutcome: 'record_exists',
         });
       }
@@ -753,7 +870,7 @@ const handler = async (event, context) => {
       throw error;
     }
 
-    log('info', 'Invocation complete', { gameID, champion: wTeam });
+    log('info', 'Invocation complete', { gameID, seasonId, champion: wTeam });
     return {
       statusCode: 200,
       body: JSON.stringify({ message: `Winner ${wTeam} saved` }),

--- a/lambdas/http-api/index.js
+++ b/lambdas/http-api/index.js
@@ -267,6 +267,32 @@ function getSeasonMeta(seasonId) {
   };
 }
 
+async function isDraftWriteWindowOpen(seasonContext) {
+  // Emergency override for operator-managed incidents.
+  if (parseBool(process.env.ALLOW_IN_SEASON_DRAFT_WRITES, false)) {
+    return true;
+  }
+
+  const seasonMeta = getSeasonMeta(seasonContext.seasonId);
+  if (seasonMeta.seasonOver) {
+    return true;
+  }
+
+  // Pre-season: no recorded games yet, so drafting is still allowed.
+  const existingRecords = await listGameRecords(seasonContext.gameRecordsTable);
+  return existingRecords.length === 0;
+}
+
+async function guardDraftWriteWindow(event, seasonContext) {
+  const allowed = await isDraftWriteWindowOpen(seasonContext);
+  if (allowed) return null;
+
+  return response(event, 409, {
+    error:
+      'Draft/team updates are locked during active season. Updates are only allowed pre-season (no games recorded) or off-season (seasonOver=true).',
+  });
+}
+
 function coerceId(value) {
   const asNumber = Number(value);
   return Number.isNaN(asNumber) ? value : asNumber;
@@ -647,6 +673,13 @@ export const handler = async (event) => {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
       }
+      const draftWriteGuardResponse = await guardDraftWriteWindow(
+        event,
+        seasonContext
+      );
+      if (draftWriteGuardResponse) {
+        return draftWriteGuardResponse;
+      }
       await resetTeams(seasonContext.playersTable);
       return response(event, 200, { ok: true });
     }
@@ -655,6 +688,13 @@ export const handler = async (event) => {
     if (teamPatchMatch && method === 'PATCH') {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
+      }
+      const draftWriteGuardResponse = await guardDraftWriteWindow(
+        event,
+        seasonContext
+      );
+      if (draftWriteGuardResponse) {
+        return draftWriteGuardResponse;
       }
       const body = parseBody(event.body);
       const team = body?.team;
@@ -809,6 +849,13 @@ export const handler = async (event) => {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
       }
+      const draftWriteGuardResponse = await guardDraftWriteWindow(
+        event,
+        seasonContext
+      );
+      if (draftWriteGuardResponse) {
+        return draftWriteGuardResponse;
+      }
       const patch = parseBody(event.body);
       try {
         const state = await updateDraftState(patch);
@@ -831,6 +878,13 @@ export const handler = async (event) => {
     if (path === '/draft/select-team' && method === 'POST') {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
+      }
+      const draftWriteGuardResponse = await guardDraftWriteWindow(
+        event,
+        seasonContext
+      );
+      if (draftWriteGuardResponse) {
+        return draftWriteGuardResponse;
       }
       const { playerId, team } = parseBody(event.body);
       if (!playerId || !team) {

--- a/lambdas/http-api/index.js
+++ b/lambdas/http-api/index.js
@@ -5,20 +5,25 @@ const dynamoDB = new AWS.DynamoDB.DocumentClient({
   region: process.env.AWS_REGION || 'us-east-1',
 });
 
-const PLAYERS_TABLE = process.env.PLAYERS_TABLE || 'Players';
-const GAME_RECORDS_TABLE = process.env.GAME_RECORDS_TABLE || 'GameRecords';
 const GAME_OPTIONS_TABLE = process.env.GAME_OPTIONS_TABLE || 'GameOptions';
-const DRAFT_STATE_ID = process.env.DRAFT_STATE_ID || 'draftState';
+const PLAYER_SEASON_TABLE = process.env.PLAYER_SEASON_TABLE || 'PlayerSeason';
+const PLAYER_LIFETIME_TABLE = process.env.PLAYER_LIFETIME_TABLE || 'PlayerLifetime';
+const GAME_RECORDS_V2_TABLE = process.env.GAME_RECORDS_V2_TABLE || 'GameRecordsV2';
+const DRAFT_STATE_TABLE = process.env.DRAFT_STATE_TABLE || 'DraftState';
+const SEASON_CATALOG_ID = process.env.SEASON_CATALOG_ID || 'seasonCatalog';
 const CORS_ORIGIN = process.env.CORS_ORIGIN || '*';
 const CACHE_TTLS = {
-  roster: Number(process.env.PLAYERS_CACHE_TTL) || 60 * 60 * 6, // 6 hours
-  gameRecords: Number(process.env.GAME_RECORDS_CACHE_TTL) || 60 * 15, // 15 minutes
-  playingDay: Number(process.env.PLAYING_DAY_CACHE_TTL) || 60 * 5, // 5 minutes
-  nonPlayingDay: Number(process.env.NON_PLAYING_DAY_CACHE_TTL) || 60 * 60 * 24, // 24 hours
+  roster: Number(process.env.PLAYERS_CACHE_TTL) || 60 * 60 * 6,
+  gameRecords: Number(process.env.GAME_RECORDS_CACHE_TTL) || 60 * 15,
+  playingDay: Number(process.env.PLAYING_DAY_CACHE_TTL) || 60 * 5,
+  nonPlayingDay: Number(process.env.NON_PLAYING_DAY_CACHE_TTL) || 60 * 60 * 24,
   staleWhileRevalidate: Number(process.env.STALE_WHILE_REVALIDATE) || 60 * 5,
-  staleWhileRevalidateLong: Number(process.env.STALE_WHILE_REVALIDATE_LONG) || 60 * 60, // 1 hour
+  staleWhileRevalidateLong: Number(process.env.STALE_WHILE_REVALIDATE_LONG) || 60 * 60,
   staleIfError: Number(process.env.STALE_IF_ERROR) || 60,
 };
+
+const DEFAULT_SEASON = normalizeSeasonId(process.env.DEFAULT_SEASON) || 'season2';
+
 const ALLOWED_HOSTS = ['inseasoncup.com'];
 const NHL_API_BASE =
   process.env.NHL_API_BASE || process.env.API_URL || 'https://api-web.nhle.com/v1';
@@ -26,7 +31,7 @@ const NHL_API_BASE =
 const NHL_TEAMS = (process.env.NHL_TEAMS ||
   'ANA,BOS,BUF,CGY,CAR,CHI,COL,CBJ,DAL,DET,EDM,FLA,LAK,MIN,MTL,NSH,NJD,NYI,NYR,OTT,PHI,PIT,SJS,SEA,STL,TBL,TOR,UTA,VAN,VGK,WSH,WPG')
   .split(',')
-  .map((t) => t.trim())
+  .map((team) => team.trim())
   .filter(Boolean);
 
 const DEFAULT_DRAFT_STATE = Object.freeze({
@@ -73,9 +78,11 @@ function buildCacheControl(ttlSeconds, options = {}) {
 function getCorsOrigin(event) {
   const origin = event?.headers?.origin || event?.headers?.Origin;
   if (!origin) return CORS_ORIGIN === '*' ? '*' : null;
+
   try {
     const { hostname, protocol } = new URL(origin);
     if (!['http:', 'https:'].includes(protocol)) return null;
+
     if (
       hostname === 'localhost' ||
       hostname === '127.0.0.1' ||
@@ -85,11 +92,13 @@ function getCorsOrigin(event) {
     ) {
       return origin;
     }
+
     if (ALLOWED_HOSTS.includes(hostname)) return origin;
-    if (ALLOWED_HOSTS.some((h) => hostname.endsWith(`.${h}`))) return origin;
-  } catch (err) {
-    console.error('Invalid origin header', origin, err);
+    if (ALLOWED_HOSTS.some((host) => hostname.endsWith(`.${host}`))) return origin;
+  } catch (error) {
+    console.error('Invalid origin header', origin, error);
   }
+
   return CORS_ORIGIN === '*' ? '*' : null;
 }
 
@@ -100,14 +109,19 @@ function buildHeaders(event, cacheOptions = null) {
     'Access-Control-Allow-Methods': 'GET,POST,PATCH,OPTIONS',
     Vary: 'Origin',
   };
-  if (origin) base['Access-Control-Allow-Origin'] = origin;
+
+  if (origin) {
+    base['Access-Control-Allow-Origin'] = origin;
+  }
+
   if (cacheOptions?.ttlSeconds) {
     const cacheControl = buildCacheControl(cacheOptions.ttlSeconds, cacheOptions);
     if (cacheControl) {
       base['Cache-Control'] = cacheControl;
-      base['CDN-Cache-Control'] = cacheControl; // Some CDNs (e.g., CloudFront) respect this override.
+      base['CDN-Cache-Control'] = cacheControl;
     }
   }
+
   return base;
 }
 
@@ -123,11 +137,13 @@ function normalizePath(event) {
   const raw = event?.rawPath || event?.path || '/';
   const stage = event?.requestContext?.stage;
   let path = raw;
+
   if (stage && path.startsWith(`/${stage}/`)) {
-    path = path.slice(stage.length + 1); // remove "/{stage}"
+    path = path.slice(stage.length + 1);
   } else if (stage && path === `/${stage}`) {
     path = '/';
   }
+
   return path.endsWith('/') && path !== '/' ? path.slice(0, -1) : path;
 }
 
@@ -143,8 +159,8 @@ function parseBody(body) {
   if (!body) return {};
   try {
     return JSON.parse(body);
-  } catch (err) {
-    console.error('Body parse failed', err);
+  } catch (error) {
+    console.error('Body parse failed', error);
     return {};
   }
 }
@@ -152,18 +168,17 @@ function parseBody(body) {
 function getHeaderValue(event, headerName) {
   const headers = event?.headers || {};
   const target = String(headerName || '').toLowerCase();
-  const matchedKey = Object.keys(headers).find(
+  const matched = Object.keys(headers).find(
     (key) => String(key).toLowerCase() === target
   );
-  if (!matchedKey) return undefined;
-  return headers[matchedKey];
+  return matched ? headers[matched] : undefined;
 }
 
 function isAuthorized(event) {
   const requiredAdminToken = process.env.ADMIN_API_TOKEN;
   if (!requiredAdminToken) return true;
-  const providedToken = getHeaderValue(event, 'x-admin-token');
-  return providedToken === requiredAdminToken;
+  const provided = getHeaderValue(event, 'x-admin-token');
+  return provided === requiredAdminToken;
 }
 
 function getQueryParams(event) {
@@ -177,6 +192,8 @@ function getQueryParams(event) {
 function normalizeSeasonId(value) {
   if (!value) return null;
   const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return null;
+
   const seasonMatch = normalized.match(/^season(\d+)$/);
   if (seasonMatch) {
     const seasonNumber = Number(seasonMatch[1]);
@@ -185,59 +202,154 @@ function normalizeSeasonId(value) {
     }
     return null;
   }
-  const seasonNumber = Number(normalized);
-  if (Number.isInteger(seasonNumber) && seasonNumber > 0) {
-    return `season${seasonNumber}`;
+
+  const numeric = Number(normalized);
+  if (Number.isInteger(numeric) && numeric > 0) {
+    return `season${numeric}`;
   }
+
   return null;
 }
 
 function getSeasonNumber(seasonId) {
-  const seasonMatch = String(seasonId || '').match(/^season(\d+)$/);
-  if (!seasonMatch) return null;
-  const seasonNumber = Number(seasonMatch[1]);
-  return Number.isInteger(seasonNumber) && seasonNumber > 0
-    ? seasonNumber
-    : null;
+  const match = String(seasonId || '').match(/^season(\d+)$/);
+  if (!match) return null;
+  const seasonNumber = Number(match[1]);
+  return Number.isInteger(seasonNumber) && seasonNumber > 0 ? seasonNumber : null;
 }
 
-function resolveSeasonTables(seasonId) {
-  const seasonNumber = getSeasonNumber(seasonId) || 2;
-  const playersTableOverride = process.env[`PLAYERS_TABLE_SEASON${seasonNumber}`];
-  const gameRecordsTableOverride =
-    process.env[`GAME_RECORDS_TABLE_SEASON${seasonNumber}`];
+function toSeasonLabel(seasonId) {
+  const seasonNumber = getSeasonNumber(seasonId);
+  return seasonNumber ? String(seasonNumber) : String(seasonId || '');
+}
+
+function normalizeSeasonOption(entry) {
+  if (typeof entry === 'string') {
+    const id = normalizeSeasonId(entry);
+    if (!id) return null;
+    return { id, label: toSeasonLabel(id), status: null };
+  }
+
+  if (!entry || typeof entry !== 'object') return null;
+  const id = normalizeSeasonId(entry.id || entry.value);
+  if (!id) return null;
 
   return {
-    players:
-      playersTableOverride ||
-      (seasonNumber === 2 ? PLAYERS_TABLE : `${PLAYERS_TABLE}-Season${seasonNumber}`),
-    gameRecords:
-      gameRecordsTableOverride ||
-      (seasonNumber === 2
-        ? GAME_RECORDS_TABLE
-        : `${GAME_RECORDS_TABLE}-Season${seasonNumber}`),
+    id,
+    label: String(entry.label || toSeasonLabel(id)),
+    status: entry.status || null,
   };
+}
+
+function parseSeasonsFromEnv() {
+  const raw = String(process.env.AVAILABLE_SEASONS || '')
+    .split(',')
+    .map((value) => normalizeSeasonId(value))
+    .filter(Boolean);
+
+  const unique = [];
+  const seen = new Set();
+  raw.forEach((seasonId) => {
+    if (seen.has(seasonId)) return;
+    seen.add(seasonId);
+    unique.push(seasonId);
+  });
+
+  if (!seen.has(DEFAULT_SEASON)) {
+    unique.push(DEFAULT_SEASON);
+  }
+  if (!seen.has('season1')) {
+    unique.unshift('season1');
+  }
+
+  return unique.map((seasonId) => ({
+    id: seasonId,
+    label: toSeasonLabel(seasonId),
+    status: null,
+  }));
+}
+
+async function getSeasonCatalogItem() {
+  const result = await dynamoDB
+    .get({
+      TableName: GAME_OPTIONS_TABLE,
+      Key: { id: SEASON_CATALOG_ID },
+    })
+    .promise();
+  return result.Item || null;
+}
+
+async function getSeasonOptions() {
+  const envFallback = {
+    defaultSeason: DEFAULT_SEASON,
+    seasons: parseSeasonsFromEnv(),
+    updatedAt: null,
+  };
+
+  try {
+    const item = await getSeasonCatalogItem();
+    if (!item) return envFallback;
+
+    const defaultSeason =
+      normalizeSeasonId(item.defaultSeason || item.currentSeason) || DEFAULT_SEASON;
+
+    const normalized = Array.isArray(item.seasons)
+      ? item.seasons.map(normalizeSeasonOption).filter(Boolean)
+      : [];
+
+    const merged = [];
+    const seen = new Set();
+
+    normalized.forEach((entry) => {
+      if (seen.has(entry.id)) return;
+      seen.add(entry.id);
+      merged.push(entry);
+    });
+
+    if (!seen.has(defaultSeason)) {
+      merged.push({
+        id: defaultSeason,
+        label: toSeasonLabel(defaultSeason),
+        status: null,
+      });
+    }
+
+    if (merged.length === 0) {
+      return envFallback;
+    }
+
+    merged.sort((a, b) => {
+      const aNum = getSeasonNumber(a.id) || Number.MAX_SAFE_INTEGER;
+      const bNum = getSeasonNumber(b.id) || Number.MAX_SAFE_INTEGER;
+      return aNum - bNum;
+    });
+
+    return {
+      defaultSeason,
+      seasons: merged,
+      updatedAt: item.updatedAt || null,
+    };
+  } catch (error) {
+    console.error('Failed to load season options from GameOptions:', error);
+    return envFallback;
+  }
 }
 
 function getSeasonContext(event) {
   const query = getQueryParams(event);
   const requestedSeasonRaw = query?.season;
   const requestedSeason = normalizeSeasonId(requestedSeasonRaw);
+
   const hasInvalidSeasonQuery =
     requestedSeasonRaw !== undefined &&
     requestedSeasonRaw !== null &&
     requestedSeasonRaw !== '' &&
     !requestedSeason;
-  const defaultSeason = normalizeSeasonId(process.env.DEFAULT_SEASON) || 'season2';
-  const seasonId = requestedSeason || defaultSeason;
-  const tableConfig = resolveSeasonTables(seasonId);
 
   return {
     requestedSeason,
     hasInvalidSeasonQuery,
-    seasonId,
-    playersTable: tableConfig.players,
-    gameRecordsTable: tableConfig.gameRecords,
+    seasonId: requestedSeason || DEFAULT_SEASON,
   };
 }
 
@@ -247,7 +359,7 @@ function parseBool(value, fallback = false) {
 }
 
 function getSeasonMeta(seasonId) {
-  const envPrefix = seasonId.toUpperCase(); // e.g. SEASON2
+  const envPrefix = String(seasonId || '').toUpperCase();
   const regularSeasonEnd = process.env[`${envPrefix}_REGULAR_SEASON_END`] || null;
   const playoffsStart = process.env[`${envPrefix}_PLAYOFFS_START`] || null;
   const explicitSeasonOver = process.env[`${envPrefix}_SEASON_OVER`];
@@ -267,124 +379,329 @@ function getSeasonMeta(seasonId) {
   };
 }
 
-async function isDraftWriteWindowOpen(seasonContext) {
-  // Emergency override for operator-managed incidents.
-  if (parseBool(process.env.ALLOW_IN_SEASON_DRAFT_WRITES, false)) {
-    return true;
-  }
-
-  const seasonMeta = getSeasonMeta(seasonContext.seasonId);
-  if (seasonMeta.seasonOver) {
-    return true;
-  }
-
-  // Pre-season: no recorded games yet, so drafting is still allowed.
-  const existingRecords = await listGameRecords(seasonContext.gameRecordsTable);
-  return existingRecords.length === 0;
+function normalizePlayerId(value) {
+  const normalized = String(value || '').trim();
+  return normalized || null;
 }
 
-async function guardDraftWriteWindow(event, seasonContext) {
-  const allowed = await isDraftWriteWindowOpen(seasonContext);
-  if (allowed) return null;
+function normalizeTeamCode(value) {
+  const normalized = String(value || '').trim().toUpperCase();
+  return normalized || null;
+}
 
-  return response(event, 409, {
-    error:
-      'Draft/team updates are locked during active season. Updates are only allowed pre-season (no games recorded) or off-season (seasonOver=true).',
+function normalizeTeams(teams) {
+  if (!Array.isArray(teams)) return [];
+  const unique = new Set();
+  teams.forEach((team) => {
+    const normalized = normalizeTeamCode(team);
+    if (normalized) {
+      unique.add(normalized);
+    }
+  });
+  return Array.from(unique);
+}
+
+async function queryAll(params) {
+  const items = [];
+  let ExclusiveStartKey;
+
+  do {
+    const page = await dynamoDB
+      .query({
+        ...params,
+        ...(ExclusiveStartKey ? { ExclusiveStartKey } : {}),
+      })
+      .promise();
+
+    items.push(...(page.Items || []));
+    ExclusiveStartKey = page.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+
+  return items;
+}
+
+async function scanAll(params) {
+  const items = [];
+  let ExclusiveStartKey;
+
+  do {
+    const page = await dynamoDB
+      .scan({
+        ...params,
+        ...(ExclusiveStartKey ? { ExclusiveStartKey } : {}),
+      })
+      .promise();
+
+    items.push(...(page.Items || []));
+    ExclusiveStartKey = page.LastEvaluatedKey;
+  } while (ExclusiveStartKey);
+
+  return items;
+}
+
+async function listPlayerSeasonRows(seasonId) {
+  return queryAll({
+    TableName: PLAYER_SEASON_TABLE,
+    KeyConditionExpression: '#seasonId = :seasonId',
+    ExpressionAttributeNames: {
+      '#seasonId': 'seasonId',
+    },
+    ExpressionAttributeValues: {
+      ':seasonId': seasonId,
+    },
   });
 }
 
-function coerceId(value) {
-  const asNumber = Number(value);
-  return Number.isNaN(asNumber) ? value : asNumber;
+async function listPlayerLifetimeRows() {
+  return scanAll({
+    TableName: PLAYER_LIFETIME_TABLE,
+  });
 }
 
-function getToday(tz = 'America/New_York') {
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: tz,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(new Date());
-}
-
-async function listPlayers(tableName = PLAYERS_TABLE) {
-  const result = await dynamoDB.scan({ TableName: tableName }).promise();
-  return result.Items || [];
-}
-
-async function getPlayerByName(name, tableName = PLAYERS_TABLE) {
-  const res = await dynamoDB
-    .query({
-      TableName: tableName,
-      IndexName: 'NameIndex',
-      KeyConditionExpression: '#n = :name',
-      ExpressionAttributeNames: { '#n': 'name' },
-      ExpressionAttributeValues: { ':name': name },
-      Limit: 1,
+async function getPlayerSeasonRow(seasonId, playerId) {
+  const result = await dynamoDB
+    .get({
+      TableName: PLAYER_SEASON_TABLE,
+      Key: {
+        seasonId,
+        playerId,
+      },
     })
     .promise();
-  return res.Items?.[0] || null;
+  return result.Item || null;
 }
 
-async function getPlayerById(id, tableName = PLAYERS_TABLE) {
-  const res = await dynamoDB
-    .get({ TableName: tableName, Key: { id } })
+async function getPlayerLifetimeRow(playerId) {
+  const result = await dynamoDB
+    .get({
+      TableName: PLAYER_LIFETIME_TABLE,
+      Key: { playerId },
+    })
     .promise();
-  return res.Item || null;
+  return result.Item || null;
 }
 
-async function updatePlayerTeams(id, team, action = 'add', tableName = PLAYERS_TABLE) {
-  const player = await getPlayerById(id, tableName);
-  if (!player) throw new Error(`Player ${id} not found`);
+function mergePlayerRows({ seasonId, playerId, seasonRow, lifetimeRow }) {
+  const normalizedPlayerId = normalizePlayerId(playerId);
+  const titleDefenses = Number(seasonRow?.titleDefenses || 0);
+  const totalDefenses = Number(lifetimeRow?.totalDefenses || 0);
+  const championships = Number(lifetimeRow?.championships || 0);
 
-  const currentTeams = Array.isArray(player.teams) ? [...player.teams] : [];
+  return {
+    id: normalizedPlayerId,
+    playerId: normalizedPlayerId,
+    seasonId,
+    name: seasonRow?.name || lifetimeRow?.name || normalizedPlayerId,
+    teams: normalizeTeams(seasonRow?.teams),
+    titleDefenses: Number.isFinite(titleDefenses) ? titleDefenses : 0,
+    totalDefenses: Number.isFinite(totalDefenses) ? totalDefenses : 0,
+    championships: Number.isFinite(championships) ? championships : 0,
+    updatedAt: seasonRow?.updatedAt || lifetimeRow?.updatedAt || null,
+  };
+}
+
+async function listPlayers(seasonId) {
+  const [seasonRows, lifetimeRows] = await Promise.all([
+    listPlayerSeasonRows(seasonId),
+    listPlayerLifetimeRows(),
+  ]);
+
+  const seasonById = new Map();
+  seasonRows.forEach((row) => {
+    const playerId = normalizePlayerId(row.playerId);
+    if (playerId) seasonById.set(playerId, row);
+  });
+
+  const lifetimeById = new Map();
+  lifetimeRows.forEach((row) => {
+    const playerId = normalizePlayerId(row.playerId || row.id);
+    if (playerId) lifetimeById.set(playerId, row);
+  });
+
+  const allPlayerIds = new Set([
+    ...Array.from(seasonById.keys()),
+    ...Array.from(lifetimeById.keys()),
+  ]);
+
+  return Array.from(allPlayerIds)
+    .map((playerId) =>
+      mergePlayerRows({
+        seasonId,
+        playerId,
+        seasonRow: seasonById.get(playerId),
+        lifetimeRow: lifetimeById.get(playerId),
+      })
+    )
+    .sort((a, b) => String(a.name).localeCompare(String(b.name)));
+}
+
+async function getPlayerByName(seasonId, name) {
+  const players = await listPlayers(seasonId);
+  return (
+    players.find(
+      (player) =>
+        String(player?.name || '').toLowerCase() === String(name || '').toLowerCase()
+    ) || null
+  );
+}
+
+async function getPlayerById(seasonId, playerId) {
+  const normalizedPlayerId = normalizePlayerId(playerId);
+  if (!normalizedPlayerId) return null;
+
+  const [seasonRow, lifetimeRow] = await Promise.all([
+    getPlayerSeasonRow(seasonId, normalizedPlayerId),
+    getPlayerLifetimeRow(normalizedPlayerId),
+  ]);
+
+  if (!seasonRow && !lifetimeRow) return null;
+
+  return mergePlayerRows({
+    seasonId,
+    playerId: normalizedPlayerId,
+    seasonRow,
+    lifetimeRow,
+  });
+}
+
+async function ensurePlayerSeasonRow(seasonId, playerId) {
+  const normalizedPlayerId = normalizePlayerId(playerId);
+  if (!normalizedPlayerId) {
+    throw new Error('playerId is required');
+  }
+
+  const existing = await getPlayerSeasonRow(seasonId, normalizedPlayerId);
+  if (existing) return existing;
+
+  const lifetimeRow = await getPlayerLifetimeRow(normalizedPlayerId);
+  const now = new Date().toISOString();
+  const created = {
+    seasonId,
+    playerId: normalizedPlayerId,
+    name: lifetimeRow?.name || normalizedPlayerId,
+    teams: [],
+    titleDefenses: 0,
+    updatedAt: now,
+  };
+
+  try {
+    await dynamoDB
+      .put({
+        TableName: PLAYER_SEASON_TABLE,
+        Item: created,
+        ConditionExpression:
+          'attribute_not_exists(#seasonId) AND attribute_not_exists(#playerId)',
+        ExpressionAttributeNames: {
+          '#seasonId': 'seasonId',
+          '#playerId': 'playerId',
+        },
+      })
+      .promise();
+  } catch (error) {
+    if (error?.code !== 'ConditionalCheckFailedException') {
+      throw error;
+    }
+  }
+
+  return (await getPlayerSeasonRow(seasonId, normalizedPlayerId)) || created;
+}
+
+async function updatePlayerTeams(seasonId, playerId, team, action = 'add') {
+  const normalizedPlayerId = normalizePlayerId(playerId);
+  if (!normalizedPlayerId) throw new Error('playerId is required');
+
+  const seasonRow = await ensurePlayerSeasonRow(seasonId, normalizedPlayerId);
+  const currentTeams = normalizeTeams(seasonRow.teams);
+  const normalizedTeam = normalizeTeamCode(team);
+
+  if (!normalizedTeam) {
+    throw new Error('team is required');
+  }
+
   const nextTeams =
     action === 'remove'
-      ? currentTeams.filter((t) => t !== team)
-      : currentTeams.includes(team)
+      ? currentTeams.filter((candidate) => candidate !== normalizedTeam)
+      : currentTeams.includes(normalizedTeam)
       ? currentTeams
-      : [...currentTeams, team];
+      : [...currentTeams, normalizedTeam];
 
-  const res = await dynamoDB
+  const updatedAt = new Date().toISOString();
+
+  await dynamoDB
     .update({
-      TableName: tableName,
-      Key: { id },
-      UpdateExpression: 'SET teams = :teams, updatedAt = :ts',
+      TableName: PLAYER_SEASON_TABLE,
+      Key: {
+        seasonId,
+        playerId: normalizedPlayerId,
+      },
+      UpdateExpression: 'SET teams = :teams, updatedAt = :updatedAt',
       ExpressionAttributeValues: {
         ':teams': nextTeams,
-        ':ts': new Date().toISOString(),
+        ':updatedAt': updatedAt,
       },
-      ReturnValues: 'ALL_NEW',
     })
     .promise();
 
-  return res.Attributes;
+  return getPlayerById(seasonId, normalizedPlayerId);
 }
 
-async function resetTeams(tableName = PLAYERS_TABLE) {
-  const allPlayers = await listPlayers(tableName);
-  const promises = allPlayers.map((p) =>
-    dynamoDB
+async function resetTeams(seasonId) {
+  const seasonRows = await listPlayerSeasonRows(seasonId);
+  const updates = seasonRows.map((row) => {
+    const playerId = normalizePlayerId(row.playerId);
+    if (!playerId) return Promise.resolve();
+
+    return dynamoDB
       .update({
-        TableName: tableName,
-        Key: { id: p.id },
-        UpdateExpression: 'REMOVE teams',
+        TableName: PLAYER_SEASON_TABLE,
+        Key: {
+          seasonId,
+          playerId,
+        },
+        UpdateExpression: 'SET teams = :teams, updatedAt = :updatedAt',
+        ExpressionAttributeValues: {
+          ':teams': [],
+          ':updatedAt': new Date().toISOString(),
+        },
       })
-      .promise()
-  );
-  await Promise.all(promises);
+      .promise();
+  });
+
+  await Promise.all(updates);
 }
 
-async function listGameRecords(tableName = GAME_RECORDS_TABLE) {
-  const result = await dynamoDB.scan({ TableName: tableName }).promise();
-  return result.Items || [];
+function normalizeGameRecord(record = {}) {
+  const id = Number(record.id ?? record.gameId);
+  const gameId = Number.isFinite(id) ? id : record.id ?? record.gameId ?? null;
+
+  return {
+    ...record,
+    id: gameId,
+    gameId,
+  };
+}
+
+async function listGameRecords(seasonId) {
+  const records = await queryAll({
+    TableName: GAME_RECORDS_V2_TABLE,
+    KeyConditionExpression: '#seasonId = :seasonId',
+    ExpressionAttributeNames: {
+      '#seasonId': 'seasonId',
+    },
+    ExpressionAttributeValues: {
+      ':seasonId': seasonId,
+    },
+  });
+
+  return records.map(normalizeGameRecord);
 }
 
 async function getGameOptions() {
-  const res = await dynamoDB
+  const result = await dynamoDB
     .get({ TableName: GAME_OPTIONS_TABLE, Key: { id: 'currentChampion' } })
     .promise();
-  return res.Item || {};
+
+  return result.Item || {};
 }
 
 async function setGameId(gameID) {
@@ -399,19 +716,29 @@ async function setGameId(gameID) {
     return null;
   }
 
-  const res = await dynamoDB
+  const result = await dynamoDB
     .update({
       TableName: GAME_OPTIONS_TABLE,
       Key: { id: 'currentChampion' },
-      UpdateExpression: 'SET gameID = :g, updatedAt = :ts',
+      UpdateExpression: 'SET gameID = :gameID, updatedAt = :updatedAt',
       ExpressionAttributeValues: {
-        ':g': gameID,
-        ':ts': new Date().toISOString(),
+        ':gameID': gameID,
+        ':updatedAt': new Date().toISOString(),
       },
       ReturnValues: 'UPDATED_NEW',
     })
     .promise();
-  return res.Attributes?.gameID || gameID;
+
+  return result.Attributes?.gameID || gameID;
+}
+
+function getToday(tz = 'America/New_York') {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
 }
 
 async function fetchSchedule(date) {
@@ -419,15 +746,18 @@ async function fetchSchedule(date) {
   return new Promise((resolve, reject) => {
     const req = https.get(url, (res) => {
       let data = '';
-      res.on('data', (chunk) => (data += chunk));
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
       res.on('end', () => {
         try {
           resolve(JSON.parse(data));
-        } catch (err) {
-          reject(err);
+        } catch (error) {
+          reject(error);
         }
       });
     });
+
     req.on('error', reject);
     req.setTimeout(8000, () => {
       req.destroy(new Error('Request timed out'));
@@ -438,59 +768,93 @@ async function fetchSchedule(date) {
 function findChampionGame(schedule, champion, date) {
   const gameWeek = schedule?.gameWeek;
   if (!Array.isArray(gameWeek)) return null;
-  const today = gameWeek.find((d) => d?.date === date);
+
+  const today = gameWeek.find((entry) => entry?.date === date);
   const games = today?.games || [];
-  for (const g of games) {
-    const home = g?.homeTeam?.abbrev;
-    const away = g?.awayTeam?.abbrev;
-    if (home === champion || away === champion) return g.id;
+
+  for (const game of games) {
+    const home = game?.homeTeam?.abbrev;
+    const away = game?.awayTeam?.abbrev;
+    if (home === champion || away === champion) {
+      return game.id;
+    }
   }
+
   return null;
 }
 
-async function ensureDraftState() {
-  const res = await dynamoDB
-    .get({ TableName: GAME_OPTIONS_TABLE, Key: { id: DRAFT_STATE_ID } })
+async function getDraftStateRow(seasonId) {
+  const result = await dynamoDB
+    .get({
+      TableName: DRAFT_STATE_TABLE,
+      Key: { draftId: seasonId },
+    })
     .promise();
-  if (res.Item?.state) {
-    const state = { ...res.Item.state };
-    const hadAvailableTeams = Array.isArray(state.availableTeams);
-    if (!Array.isArray(state.availableTeams)) {
-      state.availableTeams = [...NHL_TEAMS];
-    }
-    const rawVersion = state.version;
-    const parsedVersion = Number(state.version);
-    state.version =
-      Number.isInteger(parsedVersion) && parsedVersion >= 0 ? parsedVersion : 0;
-    state.updatedAt = state.updatedAt || res.Item.updatedAt || null;
 
-    const needsNormalization =
-      !hadAvailableTeams ||
-      rawVersion !== state.version ||
-      !state.updatedAt;
-    if (needsNormalization) {
-      const now = new Date().toISOString();
-      state.updatedAt = now;
-      await dynamoDB
-        .update({
-          TableName: GAME_OPTIONS_TABLE,
-          Key: { id: DRAFT_STATE_ID },
-          UpdateExpression: 'SET #state = :state, #updatedAt = :ts',
-          ExpressionAttributeNames: {
-            '#state': 'state',
-            '#updatedAt': 'updatedAt',
-          },
-          ExpressionAttributeValues: {
-            ':state': state,
-            ':ts': now,
-          },
-        })
-        .promise();
-    }
-    return state;
+  return result.Item || null;
+}
+
+function normalizeDraftState(rawState) {
+  if (!rawState || typeof rawState !== 'object') {
+    return {
+      ...DEFAULT_DRAFT_STATE,
+      availableTeams: [...NHL_TEAMS],
+      version: 0,
+      updatedAt: null,
+    };
   }
 
-  const state = {
+  const parsedVersion = Number(rawState.version);
+  const parsedPickNumber = Number(rawState.currentPickNumber);
+
+  return {
+    draftStarted: Boolean(rawState.draftStarted),
+    pickOrder: Array.isArray(rawState.pickOrder)
+      ? rawState.pickOrder.map((id) => normalizePlayerId(id)).filter(Boolean)
+      : [],
+    currentPicker: normalizePlayerId(rawState.currentPicker),
+    currentPickNumber:
+      Number.isInteger(parsedPickNumber) && parsedPickNumber >= 0
+        ? parsedPickNumber
+        : 0,
+    availableTeams: Array.isArray(rawState.availableTeams)
+      ? normalizeTeams(rawState.availableTeams)
+      : [...NHL_TEAMS],
+    version: Number.isInteger(parsedVersion) && parsedVersion >= 0 ? parsedVersion : 0,
+    updatedAt: rawState.updatedAt || null,
+  };
+}
+
+async function ensureDraftState(seasonId) {
+  const existing = await getDraftStateRow(seasonId);
+  const normalized = normalizeDraftState(existing);
+
+  if (existing) {
+    const needsNormalization =
+      !Array.isArray(existing.availableTeams) ||
+      !Number.isInteger(Number(existing.version)) ||
+      !existing.updatedAt;
+
+    if (needsNormalization) {
+      const normalizedItem = {
+        draftId: seasonId,
+        ...normalized,
+        updatedAt: new Date().toISOString(),
+      };
+      await dynamoDB
+        .put({
+          TableName: DRAFT_STATE_TABLE,
+          Item: normalizedItem,
+        })
+        .promise();
+      return normalizeDraftState(normalizedItem);
+    }
+
+    return normalized;
+  }
+
+  const created = {
+    draftId: seasonId,
     ...DEFAULT_DRAFT_STATE,
     availableTeams: [...NHL_TEAMS],
     version: 0,
@@ -499,16 +863,13 @@ async function ensureDraftState() {
 
   await dynamoDB
     .put({
-      TableName: GAME_OPTIONS_TABLE,
-      Item: {
-        id: DRAFT_STATE_ID,
-        state,
-        updatedAt: state.updatedAt,
-      },
+      TableName: DRAFT_STATE_TABLE,
+      Item: created,
+      ConditionExpression: 'attribute_not_exists(draftId)',
     })
     .promise();
 
-  return state;
+  return normalizeDraftState(created);
 }
 
 function parseDraftStateVersion(value) {
@@ -518,67 +879,58 @@ function parseDraftStateVersion(value) {
   return parsed;
 }
 
-async function updateDraftState(patch = {}) {
+async function updateDraftState(seasonId, patch = {}) {
   if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
     throw new DraftStateValidationError('patch body must be an object');
   }
   if (patch.version === undefined) {
     throw new DraftStateValidationError('version is required');
   }
+
   const expectedVersion = parseDraftStateVersion(patch.version);
   if (expectedVersion === null) {
     throw new DraftStateValidationError('version must be a non-negative integer');
   }
 
-  const current = await ensureDraftState();
-  if (expectedVersion !== current.version) {
-    throw new DraftStateConflictError(
-      'Draft state version conflict',
-      current
-    );
+  const current = await ensureDraftState(seasonId);
+  if (current.version !== expectedVersion) {
+    throw new DraftStateConflictError('Draft state version conflict', current);
   }
 
   const patchWithoutVersion = { ...patch };
   delete patchWithoutVersion.version;
   delete patchWithoutVersion.updatedAt;
 
-  const next = {
+  const next = normalizeDraftState({
     ...current,
     ...patchWithoutVersion,
     version: current.version + 1,
     updatedAt: new Date().toISOString(),
-  };
+  });
 
   try {
     await dynamoDB
-      .update({
-        TableName: GAME_OPTIONS_TABLE,
-        Key: { id: DRAFT_STATE_ID },
-        UpdateExpression: 'SET #state = :state, #updatedAt = :ts',
-        ConditionExpression:
-          '(attribute_not_exists(#state.#version) AND :expected = :zero) OR #state.#version = :expected',
+      .put({
+        TableName: DRAFT_STATE_TABLE,
+        Item: {
+          draftId: seasonId,
+          ...next,
+        },
+        ConditionExpression: 'attribute_exists(draftId) AND #version = :expectedVersion',
         ExpressionAttributeNames: {
-          '#state': 'state',
           '#version': 'version',
-          '#updatedAt': 'updatedAt',
         },
         ExpressionAttributeValues: {
-          ':state': next,
-          ':ts': next.updatedAt,
-          ':expected': expectedVersion,
-          ':zero': 0,
+          ':expectedVersion': expectedVersion,
         },
       })
       .promise();
-  } catch (err) {
-    if (err?.code === 'ConditionalCheckFailedException') {
-      const latest = await ensureDraftState();
-      throw new DraftStateConflictError(
-        'Draft state version conflict',
-        latest
-      );
+  } catch (error) {
+    if (error?.code === 'ConditionalCheckFailedException') {
+      const latest = await ensureDraftState(seasonId);
+      throw new DraftStateConflictError('Draft state version conflict', latest);
     }
-    throw err;
+    throw error;
   }
 
   return next;
@@ -605,15 +957,21 @@ function mapChampionHistoryRecord(record = {}) {
     record.updatedAt ||
     record.createdAt ||
     null;
-  const idNumber = Number(record.id);
+
+  const gameId = Number(record.gameId ?? record.id);
+
   return {
-    gameId: Number.isFinite(idNumber) ? idNumber : record.id ?? null,
+    gameId: Number.isFinite(gameId) ? gameId : record.gameId ?? record.id ?? null,
     winnerTeam,
-    winnerScore: Number.isFinite(Number(record.wScore))
-      ? Number(record.wScore)
-      : null,
+    winnerScore:
+      Number.isFinite(Number(record.wScore)) && record.wScore !== null
+        ? Number(record.wScore)
+        : null,
     loserTeam,
-    loserScore: Number.isFinite(Number(record.lScore)) ? Number(record.lScore) : null,
+    loserScore:
+      Number.isFinite(Number(record.lScore)) && record.lScore !== null
+        ? Number(record.lScore)
+        : null,
     participants,
     recordedAt,
   };
@@ -622,17 +980,43 @@ function mapChampionHistoryRecord(record = {}) {
 function historySortKey(entry = {}) {
   const timestamp = Date.parse(entry.recordedAt || '');
   if (Number.isFinite(timestamp)) return timestamp;
+
   const gameIdNumber = Number(entry.gameId);
   if (Number.isFinite(gameIdNumber)) return gameIdNumber;
+
   return -1;
 }
 
-async function listChampionHistory(limit, tableName = GAME_RECORDS_TABLE) {
-  const records = await listGameRecords(tableName);
+async function listChampionHistory(seasonId, limit) {
+  const records = await listGameRecords(seasonId);
   return records
     .map(mapChampionHistoryRecord)
     .sort((a, b) => historySortKey(b) - historySortKey(a))
     .slice(0, limit);
+}
+
+async function isDraftWriteWindowOpen(seasonContext) {
+  if (parseBool(process.env.ALLOW_IN_SEASON_DRAFT_WRITES, false)) {
+    return true;
+  }
+
+  const seasonMeta = getSeasonMeta(seasonContext.seasonId);
+  if (seasonMeta.seasonOver) {
+    return true;
+  }
+
+  const existingRecords = await listGameRecords(seasonContext.seasonId);
+  return existingRecords.length === 0;
+}
+
+async function guardDraftWriteWindow(event, seasonContext) {
+  const allowed = await isDraftWriteWindowOpen(seasonContext);
+  if (allowed) return null;
+
+  return response(event, 409, {
+    error:
+      'Draft/team updates are locked during active season. Updates are only allowed pre-season (no games recorded) or off-season (seasonOver=true).',
+  });
 }
 
 export const handler = async (event) => {
@@ -640,7 +1024,9 @@ export const handler = async (event) => {
   const method = getMethod(event);
   const seasonContext = getSeasonContext(event);
 
-  if (method === 'OPTIONS') return response(event, 204, {});
+  if (method === 'OPTIONS') {
+    return response(event, 204, {});
+  }
 
   try {
     if (seasonContext.hasInvalidSeasonQuery) {
@@ -650,37 +1036,39 @@ export const handler = async (event) => {
       });
     }
 
-    // ---- Players ----
+    if (path === '/season/options' && method === 'GET') {
+      return response(event, 200, await getSeasonOptions(), {
+        ttlSeconds: CACHE_TTLS.nonPlayingDay,
+        staleWhileRevalidate: CACHE_TTLS.staleWhileRevalidateLong,
+        staleIfError: CACHE_TTLS.staleIfError,
+      });
+    }
+
     if (path === '/players' && method === 'GET') {
-      return response(
-        event,
-        200,
-        await listPlayers(seasonContext.playersTable),
-        {
+      return response(event, 200, await listPlayers(seasonContext.seasonId), {
         ttlSeconds: CACHE_TTLS.roster,
         staleWhileRevalidate: CACHE_TTLS.staleWhileRevalidateLong,
         staleIfError: CACHE_TTLS.staleIfError,
-        }
-      );
+      });
     }
 
     if (path.startsWith('/players/') && method === 'GET') {
       const name = decodeURIComponent(path.split('/').pop());
-      return response(event, 200, await getPlayerByName(name, seasonContext.playersTable));
+      return response(
+        event,
+        200,
+        await getPlayerByName(seasonContext.seasonId, name)
+      );
     }
 
     if (path === '/players/reset-teams' && method === 'POST') {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
       }
-      const draftWriteGuardResponse = await guardDraftWriteWindow(
-        event,
-        seasonContext
-      );
-      if (draftWriteGuardResponse) {
-        return draftWriteGuardResponse;
-      }
-      await resetTeams(seasonContext.playersTable);
+      const lockResponse = await guardDraftWriteWindow(event, seasonContext);
+      if (lockResponse) return lockResponse;
+
+      await resetTeams(seasonContext.seasonId);
       return response(event, 200, { ok: true });
     }
 
@@ -689,30 +1077,28 @@ export const handler = async (event) => {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
       }
-      const draftWriteGuardResponse = await guardDraftWriteWindow(
-        event,
-        seasonContext
-      );
-      if (draftWriteGuardResponse) {
-        return draftWriteGuardResponse;
-      }
+      const lockResponse = await guardDraftWriteWindow(event, seasonContext);
+      if (lockResponse) return lockResponse;
+
       const body = parseBody(event.body);
       const team = body?.team;
       const action = body?.action || 'add';
-      if (!team) return response(event, 400, { error: 'team is required' });
-      const playerId = coerceId(teamPatchMatch[1]);
+      if (!team) {
+        return response(event, 400, { error: 'team is required' });
+      }
+
       const updated = await updatePlayerTeams(
-        playerId,
+        seasonContext.seasonId,
+        teamPatchMatch[1],
         team,
-        action,
-        seasonContext.playersTable
+        action
       );
+
       return response(event, 200, updated);
     }
 
-    // ---- Game records ----
     if (path === '/game-records' && method === 'GET') {
-      return response(event, 200, await listGameRecords(seasonContext.gameRecordsTable), {
+      return response(event, 200, await listGameRecords(seasonContext.seasonId), {
         ttlSeconds: CACHE_TTLS.gameRecords,
         staleWhileRevalidate: CACHE_TTLS.staleWhileRevalidate,
         staleIfError: CACHE_TTLS.staleIfError,
@@ -728,17 +1114,13 @@ export const handler = async (event) => {
         });
       }
 
-      const history = await listChampionHistory(
-        limit,
-        seasonContext.gameRecordsTable
-      );
       return response(
         event,
         200,
         {
           seasonId: seasonContext.seasonId,
           limit,
-          history,
+          history: await listChampionHistory(seasonContext.seasonId, limit),
         },
         {
           ttlSeconds: CACHE_TTLS.gameRecords,
@@ -748,20 +1130,21 @@ export const handler = async (event) => {
       );
     }
 
-    // ---- Champion + game id ----
     if (path === '/champion' && method === 'GET') {
-      const opts = await getGameOptions();
-      const champion = opts.champion;
+      const gameOptions = await getGameOptions();
+      const champion = gameOptions.champion;
+
       if (!champion) {
         return response(event, 404, { error: 'Champion not set in GameOptions' });
       }
 
-      let gameID = opts.activeGameId ?? opts.gameID ?? null;
+      let gameID = gameOptions.activeGameId ?? gameOptions.gameID ?? null;
       let cacheOptions = {
         ttlSeconds: CACHE_TTLS.playingDay,
         staleWhileRevalidate: CACHE_TTLS.staleWhileRevalidate,
         staleIfError: CACHE_TTLS.staleIfError,
       };
+
       if (NHL_API_BASE) {
         try {
           const today = getToday();
@@ -781,27 +1164,37 @@ export const handler = async (event) => {
                   staleWhileRevalidate: CACHE_TTLS.staleWhileRevalidate,
                   staleIfError: CACHE_TTLS.staleIfError,
                 };
-        } catch (err) {
-          console.error('schedule lookup failed', err);
+        } catch (error) {
+          console.error('schedule lookup failed', error);
         }
       }
 
       return response(
         event,
         200,
-        { champion, gameID, activeGameId: gameID, seasonId: seasonContext.seasonId },
+        {
+          champion,
+          gameID,
+          activeGameId: gameID,
+          seasonId: seasonContext.seasonId,
+        },
         cacheOptions
       );
     }
 
     if (path === '/gameid' && method === 'GET') {
-      const opts = await getGameOptions();
-      const activeGameId = opts.activeGameId ?? opts.gameID ?? null;
+      const gameOptions = await getGameOptions();
+      const activeGameId = gameOptions.activeGameId ?? gameOptions.gameID ?? null;
       const hasActiveGame = Boolean(activeGameId);
+
       return response(
         event,
         200,
-        { gameID: activeGameId, activeGameId, seasonId: seasonContext.seasonId },
+        {
+          gameID: activeGameId,
+          activeGameId,
+          seasonId: seasonContext.seasonId,
+        },
         hasActiveGame
           ? {
               ttlSeconds: CACHE_TTLS.playingDay,
@@ -817,17 +1210,17 @@ export const handler = async (event) => {
     }
 
     if (path === '/check-status' && method === 'GET') {
-      const opts = await getGameOptions();
+      const gameOptions = await getGameOptions();
       return response(event, 200, {
         seasonId: seasonContext.seasonId,
-        champion: opts.champion ?? null,
-        gameID: opts.activeGameId ?? opts.gameID ?? null,
-        activeGameId: opts.activeGameId ?? null,
-        checkStatus: opts.checkStatus ?? null,
-        nextCheckAt: opts.nextCheckAt ?? null,
-        lastCheckedAt: opts.lastCheckedAt ?? null,
-        finalizedAt: opts.finalizedAt ?? null,
-        processedGameId: opts.processedGameId ?? null,
+        champion: gameOptions.champion ?? null,
+        gameID: gameOptions.activeGameId ?? gameOptions.gameID ?? null,
+        activeGameId: gameOptions.activeGameId ?? null,
+        checkStatus: gameOptions.checkStatus ?? null,
+        nextCheckAt: gameOptions.nextCheckAt ?? null,
+        lastCheckedAt: gameOptions.lastCheckedAt ?? null,
+        finalizedAt: gameOptions.finalizedAt ?? null,
+        processedGameId: gameOptions.processedGameId ?? null,
       });
     }
 
@@ -839,26 +1232,21 @@ export const handler = async (event) => {
       });
     }
 
-    // ---- Draft ----
     if (path === '/draft/state' && method === 'GET') {
-      const state = await ensureDraftState();
-      return response(event, 200, state);
+      return response(event, 200, await ensureDraftState(seasonContext.seasonId));
     }
 
     if (path === '/draft/state' && method === 'PATCH') {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
       }
-      const draftWriteGuardResponse = await guardDraftWriteWindow(
-        event,
-        seasonContext
-      );
-      if (draftWriteGuardResponse) {
-        return draftWriteGuardResponse;
-      }
+
+      const lockResponse = await guardDraftWriteWindow(event, seasonContext);
+      if (lockResponse) return lockResponse;
+
       const patch = parseBody(event.body);
       try {
-        const state = await updateDraftState(patch);
+        const state = await updateDraftState(seasonContext.seasonId, patch);
         return response(event, 200, state);
       } catch (error) {
         if (error instanceof DraftStateValidationError) {
@@ -879,29 +1267,36 @@ export const handler = async (event) => {
       if (!isAuthorized(event)) {
         return response(event, 401, { error: 'Unauthorized' });
       }
-      const draftWriteGuardResponse = await guardDraftWriteWindow(
-        event,
-        seasonContext
-      );
-      if (draftWriteGuardResponse) {
-        return draftWriteGuardResponse;
-      }
+
+      const lockResponse = await guardDraftWriteWindow(event, seasonContext);
+      if (lockResponse) return lockResponse;
+
       const { playerId, team } = parseBody(event.body);
       if (!playerId || !team) {
-        return response(event, 400, { error: 'playerId and team are required' });
+        return response(event, 400, {
+          error: 'playerId and team are required',
+        });
       }
+
       const updated = await updatePlayerTeams(
-        coerceId(playerId),
+        seasonContext.seasonId,
+        playerId,
         team,
-        'add',
-        seasonContext.playersTable
+        'add'
       );
-      return response(event, 200, { player: updated, team });
+
+      return response(event, 200, {
+        player: updated,
+        team,
+      });
     }
 
     return response(event, 404, { error: 'Not found', path, method });
-  } catch (err) {
-    console.error('handler error', err);
-    return response(event, 500, { error: 'Internal Server Error', detail: String(err) });
+  } catch (error) {
+    console.error('handler error', error);
+    return response(event, 500, {
+      error: 'Internal Server Error',
+      detail: String(error),
+    });
   }
 };

--- a/scripts/aws/offseason-migrate-season-data.sh
+++ b/scripts/aws/offseason-migrate-season-data.sh
@@ -1,0 +1,541 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"
+  exit 1
+fi
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+AWS_PROFILE="${AWS_PROFILE:-}"
+
+LEGACY_PLAYERS_SEASON1_TABLE="${LEGACY_PLAYERS_SEASON1_TABLE:-Players-Season1}"
+LEGACY_PLAYERS_CURRENT_TABLE="${LEGACY_PLAYERS_CURRENT_TABLE:-Players}"
+LEGACY_GAME_RECORDS_SEASON1_TABLE="${LEGACY_GAME_RECORDS_SEASON1_TABLE:-GameRecords-Season1}"
+LEGACY_GAME_RECORDS_CURRENT_TABLE="${LEGACY_GAME_RECORDS_CURRENT_TABLE:-GameRecords}"
+LEGACY_GAME_OPTIONS_TABLE="${LEGACY_GAME_OPTIONS_TABLE:-GameOptions}"
+LEGACY_DRAFT_STATE_ID="${LEGACY_DRAFT_STATE_ID:-draftState}"
+
+PLAYER_LIFETIME_TABLE="${PLAYER_LIFETIME_TABLE:-PlayerLifetime}"
+PLAYER_SEASON_TABLE="${PLAYER_SEASON_TABLE:-PlayerSeason}"
+GAME_RECORDS_V2_TABLE="${GAME_RECORDS_V2_TABLE:-GameRecordsV2}"
+DRAFT_STATE_TABLE="${DRAFT_STATE_TABLE:-DraftState}"
+SEASON_CATALOG_ID="${SEASON_CATALOG_ID:-seasonCatalog}"
+
+SEASON1_ID="${SEASON1_ID:-season1}"
+CURRENT_SEASON_ID="${CURRENT_SEASON_ID:-season2}"
+
+HTTP_API_FUNCTION_NAME="${HTTP_API_FUNCTION_NAME:-inseason-http-api}"
+CHECK_GAME_FUNCTION_NAME="${CHECK_GAME_FUNCTION_NAME:-inseason-check-game}"
+
+CREATE_TABLES="${CREATE_TABLES:-true}"
+APPLY_LAMBDA_ENV_CUTOVER="${APPLY_LAMBDA_ENV_CUTOVER:-false}"
+TAG_LEGACY_TABLES="${TAG_LEGACY_TABLES:-true}"
+
+TIMESTAMP="${TIMESTAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-tmp/season-data-migration/${TIMESTAMP}}"
+RUN_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+AWS_CMD=(aws --region "$AWS_REGION")
+if [[ -n "$AWS_PROFILE" ]]; then
+  AWS_CMD+=(--profile "$AWS_PROFILE")
+fi
+
+bool_true() {
+  case "${1,,}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+aws_cli() {
+  "${AWS_CMD[@]}" "$@"
+}
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+require_table() {
+  local table="$1"
+  if ! aws_cli dynamodb describe-table --table-name "$table" >/dev/null 2>&1; then
+    echo "Missing required table: $table"
+    exit 1
+  fi
+}
+
+table_exists() {
+  local table="$1"
+  aws_cli dynamodb describe-table --table-name "$table" >/dev/null 2>&1
+}
+
+ensure_table() {
+  local table="$1"
+  local attribute_definitions="$2"
+  local key_schema="$3"
+
+  if table_exists "$table"; then
+    log "Table exists: $table"
+    return
+  fi
+
+  log "Creating table: $table"
+  aws_cli dynamodb create-table \
+    --table-name "$table" \
+    --attribute-definitions "$attribute_definitions" \
+    --key-schema "$key_schema" \
+    --billing-mode PAY_PER_REQUEST >/dev/null
+
+  aws_cli dynamodb wait table-exists --table-name "$table"
+  log "Table ready: $table"
+}
+
+snapshot_table() {
+  local table="$1"
+  local out="$SNAPSHOT_DIR/${table}.json"
+
+  log "Snapshotting table: $table"
+  aws_cli dynamodb scan --table-name "$table" --output json > "$out"
+  local count
+  count="$(jq '.Items | length' "$out")"
+  log "Snapshot complete: $table ($count items) -> $out"
+}
+
+put_item_if_absent() {
+  local table="$1"
+  local condition_expression="$2"
+  local item_json="$3"
+
+  if aws_cli dynamodb put-item \
+      --table-name "$table" \
+      --item "$item_json" \
+      --condition-expression "$condition_expression" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  return 1
+}
+
+put_items_from_file() {
+  local table="$1"
+  local condition_expression="$2"
+  local source_file="$3"
+
+  local inserted=0
+  local skipped=0
+
+  if [[ ! -s "$source_file" ]]; then
+    log "No items to write for $table from $source_file"
+    echo "$inserted $skipped"
+    return
+  fi
+
+  while IFS= read -r item; do
+    if [[ -z "$item" ]]; then
+      continue
+    fi
+
+    if put_item_if_absent "$table" "$condition_expression" "$item"; then
+      inserted=$((inserted + 1))
+    else
+      skipped=$((skipped + 1))
+    fi
+  done < "$source_file"
+
+  log "Write summary for $table: inserted=$inserted skipped=$skipped"
+  echo "$inserted $skipped"
+}
+
+build_player_lifetime_items() {
+  local source_file="$1"
+  local out_file="$2"
+
+  jq -c --arg ts "$RUN_TS" '
+    .Items[]
+    | {
+        _playerId: (.playerId.S // .playerId.N // .id.S // .id.N // empty),
+        _name: (.name.S // ""),
+        _championships: (.championships.N // "0"),
+        _totalDefenses: (.totalDefenses.N // "0"),
+        _updatedAt: (.updatedAt.S // $ts)
+      }
+    | select(._playerId != "")
+    | {
+        playerId: { S: (._playerId | tostring) },
+        name: {
+          S: (
+            if (._name | length) > 0
+            then ._name
+            else (._playerId | tostring)
+            end
+          )
+        },
+        championships: { N: (._championships | tostring) },
+        totalDefenses: { N: (._totalDefenses | tostring) },
+        updatedAt: { S: (._updatedAt | tostring) }
+      }
+  ' "$source_file" > "$out_file"
+}
+
+build_player_season_items() {
+  local source_file="$1"
+  local out_file="$2"
+  local season_id="$3"
+
+  jq -c --arg seasonId "$season_id" --arg ts "$RUN_TS" '
+    .Items[]
+    | {
+        _playerId: (.playerId.S // .playerId.N // .id.S // .id.N // empty),
+        _name: (.name.S // ""),
+        _titleDefenses: (.titleDefenses.N // "0"),
+        _updatedAt: (.updatedAt.S // $ts),
+        _teams: (
+          if .teams.L then
+            [.teams.L[] | (.S // .N // empty)]
+          elif .teams.SS then
+            .teams.SS
+          else
+            []
+          end
+        )
+      }
+    | select(._playerId != "")
+    | {
+        seasonId: { S: $seasonId },
+        playerId: { S: (._playerId | tostring) },
+        name: {
+          S: (
+            if (._name | length) > 0
+            then ._name
+            else (._playerId | tostring)
+            end
+          )
+        },
+        teams: {
+          L: (
+            ._teams
+            | map(select(. != "") | ascii_upcase)
+            | unique
+            | map({ S: . })
+          )
+        },
+        titleDefenses: { N: (._titleDefenses | tostring) },
+        updatedAt: { S: (._updatedAt | tostring) }
+      }
+  ' "$source_file" > "$out_file"
+}
+
+build_game_records_v2_items() {
+  local source_file="$1"
+  local out_file="$2"
+  local season_id="$3"
+
+  jq -c --arg seasonId "$season_id" --arg ts "$RUN_TS" '
+    .Items[]
+    | {
+        _gameId: (.gameId.S // .gameId.N // .id.S // .id.N // empty),
+        _wTeam: (.wTeam.S // ""),
+        _wScore: (.wScore.N // "0"),
+        _lTeam: (.lTeam.S // ""),
+        _lScore: (.lScore.N // "0"),
+        _savedAt: (.savedAt.S // .updatedAt.S // $ts)
+      }
+    | select(._gameId != "")
+    | {
+        seasonId: { S: $seasonId },
+        gameId: { S: (._gameId | tostring) },
+        id: { S: (._gameId | tostring) },
+        wTeam: { S: ._wTeam },
+        wScore: { N: (._wScore | tostring) },
+        lTeam: { S: ._lTeam },
+        lScore: { N: (._lScore | tostring) },
+        savedAt: { S: (._savedAt | tostring) },
+        updatedAt: { S: (._savedAt | tostring) }
+      }
+  ' "$source_file" > "$out_file"
+}
+
+build_draft_state_item() {
+  local source_file="$1"
+  local out_file="$2"
+
+  jq -c \
+    --arg draftStateId "$LEGACY_DRAFT_STATE_ID" \
+    --arg draftId "$CURRENT_SEASON_ID" \
+    --arg ts "$RUN_TS" '
+      .Items[]
+      | select((.id.S // .id.N // "") == $draftStateId)
+      | {
+          _state: (.state.M // {}),
+          _updatedAt: (.updatedAt.S // $ts)
+        }
+      | {
+          draftId: { S: $draftId },
+          draftStarted: { BOOL: (._state.draftStarted.BOOL // false) },
+          pickOrder: {
+            L: (
+              (._state.pickOrder.L // [])
+              | map((.S // .N // empty) | tostring)
+              | map({ S: . })
+            )
+          },
+          currentPicker: (
+            if (._state.currentPicker.S // ._state.currentPicker.N // "") == ""
+            then { NULL: true }
+            else { S: ((._state.currentPicker.S // ._state.currentPicker.N) | tostring) }
+            end
+          ),
+          currentPickNumber: { N: ((._state.currentPickNumber.N // "0") | tostring) },
+          availableTeams: {
+            L: (
+              if ._state.availableTeams.L then
+                ._state.availableTeams.L
+                | map(.S // .N // empty)
+                | map(select(. != "") | ascii_upcase)
+                | unique
+                | map({ S: . })
+              elif ._state.availableTeams.SS then
+                ._state.availableTeams.SS
+                | map(select(. != "") | ascii_upcase)
+                | unique
+                | map({ S: . })
+              else
+                []
+              end
+            )
+          },
+          version: { N: ((._state.version.N // "0") | tostring) },
+          updatedAt: { S: (._updatedAt | tostring) }
+        }
+  ' "$source_file" > "$out_file"
+}
+
+upsert_season_catalog() {
+  local game_options_table="$1"
+  local payload
+
+  payload="$(jq -c -n \
+    --arg id "$SEASON_CATALOG_ID" \
+    --arg defaultSeason "$CURRENT_SEASON_ID" \
+    --arg ts "$RUN_TS" \
+    --arg season1 "$SEASON1_ID" \
+    --arg season2 "$CURRENT_SEASON_ID" '
+      {
+        id: { S: $id },
+        defaultSeason: { S: $defaultSeason },
+        seasons: {
+          L: [
+            {
+              M: {
+                id: { S: $season1 },
+                label: { S: ($season1 | sub("^season"; "")) },
+                status: { S: "complete" }
+              }
+            },
+            {
+              M: {
+                id: { S: $season2 },
+                label: { S: ($season2 | sub("^season"; "")) },
+                status: { S: "active" }
+              }
+            }
+          ]
+        },
+        updatedAt: { S: $ts }
+      }
+    '
+  )"
+
+  aws_cli dynamodb put-item \
+    --table-name "$game_options_table" \
+    --item "$payload" >/dev/null
+
+  log "Upserted season catalog item in $game_options_table (id=$SEASON_CATALOG_ID)"
+}
+
+update_lambda_env() {
+  local function_name="$1"
+
+  local current_env
+  current_env="$(aws_cli lambda get-function-configuration \
+    --function-name "$function_name" \
+    --query 'Environment.Variables' \
+    --output json)"
+
+  local merged_env
+  merged_env="$(jq -c \
+    --arg playerSeason "$PLAYER_SEASON_TABLE" \
+    --arg playerLifetime "$PLAYER_LIFETIME_TABLE" \
+    --arg recordsV2 "$GAME_RECORDS_V2_TABLE" \
+    --arg draftState "$DRAFT_STATE_TABLE" \
+    --arg defaultSeason "$CURRENT_SEASON_ID" \
+    --arg seasonCatalogId "$SEASON_CATALOG_ID" '
+      . + {
+        PLAYER_SEASON_TABLE: $playerSeason,
+        PLAYER_LIFETIME_TABLE: $playerLifetime,
+        GAME_RECORDS_V2_TABLE: $recordsV2,
+        DRAFT_STATE_TABLE: $draftState,
+        DEFAULT_SEASON: $defaultSeason,
+        SEASON_CATALOG_ID: $seasonCatalogId
+      }
+    ' <<<"$current_env")"
+
+  aws_cli lambda update-function-configuration \
+    --function-name "$function_name" \
+    --environment "Variables=$merged_env" >/dev/null
+
+  log "Updated Lambda env vars: $function_name"
+}
+
+tag_legacy_table() {
+  local table="$1"
+  local arn
+  arn="$(aws_cli dynamodb describe-table --table-name "$table" --query 'Table.TableArn' --output text)"
+
+  aws_cli dynamodb tag-resource \
+    --resource-arn "$arn" \
+    --tags "Key=migrationStatus,Value=legacy-frozen" "Key=migrationUpdatedAt,Value=${RUN_TS}" >/dev/null
+
+  log "Tagged legacy table: $table"
+}
+
+mkdir -p "$SNAPSHOT_DIR"
+
+log "Starting offseason multi-season migration"
+log "Region=$AWS_REGION profile=${AWS_PROFILE:-default} snapshotDir=$SNAPSHOT_DIR"
+
+require_table "$LEGACY_PLAYERS_SEASON1_TABLE"
+require_table "$LEGACY_PLAYERS_CURRENT_TABLE"
+require_table "$LEGACY_GAME_RECORDS_SEASON1_TABLE"
+require_table "$LEGACY_GAME_RECORDS_CURRENT_TABLE"
+require_table "$LEGACY_GAME_OPTIONS_TABLE"
+
+if bool_true "$CREATE_TABLES"; then
+  ensure_table \
+    "$PLAYER_LIFETIME_TABLE" \
+    '[{"AttributeName":"playerId","AttributeType":"S"}]' \
+    '[{"AttributeName":"playerId","KeyType":"HASH"}]'
+
+  ensure_table \
+    "$PLAYER_SEASON_TABLE" \
+    '[{"AttributeName":"seasonId","AttributeType":"S"},{"AttributeName":"playerId","AttributeType":"S"}]' \
+    '[{"AttributeName":"seasonId","KeyType":"HASH"},{"AttributeName":"playerId","KeyType":"RANGE"}]'
+
+  ensure_table \
+    "$GAME_RECORDS_V2_TABLE" \
+    '[{"AttributeName":"seasonId","AttributeType":"S"},{"AttributeName":"gameId","AttributeType":"S"}]' \
+    '[{"AttributeName":"seasonId","KeyType":"HASH"},{"AttributeName":"gameId","KeyType":"RANGE"}]'
+
+  ensure_table \
+    "$DRAFT_STATE_TABLE" \
+    '[{"AttributeName":"draftId","AttributeType":"S"}]' \
+    '[{"AttributeName":"draftId","KeyType":"HASH"}]'
+fi
+
+snapshot_table "$LEGACY_PLAYERS_SEASON1_TABLE"
+snapshot_table "$LEGACY_PLAYERS_CURRENT_TABLE"
+snapshot_table "$LEGACY_GAME_RECORDS_SEASON1_TABLE"
+snapshot_table "$LEGACY_GAME_RECORDS_CURRENT_TABLE"
+snapshot_table "$LEGACY_GAME_OPTIONS_TABLE"
+
+lifetime_items_file="$SNAPSHOT_DIR/player-lifetime-items.jsonl"
+season1_items_file="$SNAPSHOT_DIR/player-season-season1-items.jsonl"
+season_current_items_file="$SNAPSHOT_DIR/player-season-current-items.jsonl"
+game_records_s1_file="$SNAPSHOT_DIR/game-records-season1-items.jsonl"
+game_records_current_file="$SNAPSHOT_DIR/game-records-current-items.jsonl"
+draft_state_file="$SNAPSHOT_DIR/draft-state-item.jsonl"
+
+build_player_lifetime_items \
+  "$SNAPSHOT_DIR/${LEGACY_PLAYERS_CURRENT_TABLE}.json" \
+  "$lifetime_items_file"
+
+build_player_season_items \
+  "$SNAPSHOT_DIR/${LEGACY_PLAYERS_SEASON1_TABLE}.json" \
+  "$season1_items_file" \
+  "$SEASON1_ID"
+
+build_player_season_items \
+  "$SNAPSHOT_DIR/${LEGACY_PLAYERS_CURRENT_TABLE}.json" \
+  "$season_current_items_file" \
+  "$CURRENT_SEASON_ID"
+
+build_game_records_v2_items \
+  "$SNAPSHOT_DIR/${LEGACY_GAME_RECORDS_SEASON1_TABLE}.json" \
+  "$game_records_s1_file" \
+  "$SEASON1_ID"
+
+build_game_records_v2_items \
+  "$SNAPSHOT_DIR/${LEGACY_GAME_RECORDS_CURRENT_TABLE}.json" \
+  "$game_records_current_file" \
+  "$CURRENT_SEASON_ID"
+
+build_draft_state_item \
+  "$SNAPSHOT_DIR/${LEGACY_GAME_OPTIONS_TABLE}.json" \
+  "$draft_state_file"
+
+put_items_from_file \
+  "$PLAYER_LIFETIME_TABLE" \
+  'attribute_not_exists(playerId)' \
+  "$lifetime_items_file" >/dev/null
+
+put_items_from_file \
+  "$PLAYER_SEASON_TABLE" \
+  'attribute_not_exists(seasonId) AND attribute_not_exists(playerId)' \
+  "$season1_items_file" >/dev/null
+
+put_items_from_file \
+  "$PLAYER_SEASON_TABLE" \
+  'attribute_not_exists(seasonId) AND attribute_not_exists(playerId)' \
+  "$season_current_items_file" >/dev/null
+
+put_items_from_file \
+  "$GAME_RECORDS_V2_TABLE" \
+  'attribute_not_exists(seasonId) AND attribute_not_exists(gameId)' \
+  "$game_records_s1_file" >/dev/null
+
+put_items_from_file \
+  "$GAME_RECORDS_V2_TABLE" \
+  'attribute_not_exists(seasonId) AND attribute_not_exists(gameId)' \
+  "$game_records_current_file" >/dev/null
+
+if [[ -s "$draft_state_file" ]]; then
+  put_items_from_file \
+    "$DRAFT_STATE_TABLE" \
+    'attribute_not_exists(draftId)' \
+    "$draft_state_file" >/dev/null
+else
+  log "No legacy draft state found at id=$LEGACY_DRAFT_STATE_ID; skipping DraftState backfill"
+fi
+
+upsert_season_catalog "$LEGACY_GAME_OPTIONS_TABLE"
+
+if bool_true "$APPLY_LAMBDA_ENV_CUTOVER"; then
+  log "Applying Lambda env cutover"
+  update_lambda_env "$HTTP_API_FUNCTION_NAME"
+  update_lambda_env "$CHECK_GAME_FUNCTION_NAME"
+else
+  log "Skipping Lambda env cutover (set APPLY_LAMBDA_ENV_CUTOVER=true to apply)"
+fi
+
+if bool_true "$TAG_LEGACY_TABLES"; then
+  tag_legacy_table "$LEGACY_PLAYERS_SEASON1_TABLE"
+  tag_legacy_table "$LEGACY_PLAYERS_CURRENT_TABLE"
+  tag_legacy_table "$LEGACY_GAME_RECORDS_SEASON1_TABLE"
+  tag_legacy_table "$LEGACY_GAME_RECORDS_CURRENT_TABLE"
+else
+  log "Skipping legacy table tagging"
+fi
+
+log "Migration complete"
+log "Snapshots and generated payloads are in: $SNAPSHOT_DIR"
+log "Post-migration validation examples:"
+cat <<VALIDATION
+  aws --region $AWS_REGION ${AWS_PROFILE:+--profile $AWS_PROFILE }dynamodb scan --table-name $PLAYER_LIFETIME_TABLE --select COUNT
+  aws --region $AWS_REGION ${AWS_PROFILE:+--profile $AWS_PROFILE }dynamodb query --table-name $PLAYER_SEASON_TABLE --key-condition-expression 'seasonId = :s' --expression-attribute-values '{":s":{"S":"$CURRENT_SEASON_ID"}}' --select COUNT
+  aws --region $AWS_REGION ${AWS_PROFILE:+--profile $AWS_PROFILE }dynamodb query --table-name $GAME_RECORDS_V2_TABLE --key-condition-expression 'seasonId = :s' --expression-attribute-values '{":s":{"S":"$CURRENT_SEASON_ID"}}' --select COUNT
+VALIDATION

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { watch, computed, onMounted } from 'vue';
+import { watch, computed } from 'vue';
 import { useTheme } from '@/composables/useTheme';
 import { useTheme as useVuetifyTheme } from 'vuetify';
 import { useSeasonStore } from '@/store/seasonStore';
@@ -27,11 +27,6 @@ import NavigationBar from '@/components/NavigationBar.vue';
 const { isDarkTheme } = useTheme();
 const seasonStore = useSeasonStore();
 const theme = useVuetifyTheme();
-
-// Initialize season store early
-onMounted(() => {
-  seasonStore.loadSeasonFromStorage();
-});
 
 // Computed theme name based on season and dark/light mode
 const currentThemeName = computed(() => {

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch, computed } from 'vue';
+import { ref, watch, computed } from 'vue';
 import { useTheme } from '@/composables/useTheme';
 import { useSeasonStore } from '@/store/seasonStore';
 import season1Logo from '@/assets/in-season-logo-season1.png';
@@ -87,10 +87,7 @@ const currentLogo = computed(() => {
   return seasonStore.currentSeason === 'season1' ? season1Logo : season2Logo;
 });
 
-const seasonOptions = [
-  { label: '1', value: 'season1' },
-  { label: '2', value: 'season2' },
-];
+const seasonOptions = computed(() => seasonStore.seasonOptions);
 
 const handleSeasonChange = (newSeason) => {
   seasonStore.setSeason(newSeason);
@@ -119,13 +116,7 @@ watch(
   }
 );
 
-onMounted(() => {
-  // Load season from localStorage on mount
-  seasonStore.loadSeasonFromStorage();
-  selectedSeason.value = seasonStore.currentSeason;
-  // Set initial font based on current season
-  updateFontForSeason(seasonStore.currentSeason);
-});
+updateFontForSeason(seasonStore.currentSeason);
 </script>
 
 <style scoped>

--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,8 @@ import { createPinia } from 'pinia';
 import App from './App.vue';
 import router from './router';
 import vuetify from './plugins/vuetify';
-import { useThemeStore } from '@/store/themeStore'; // Import the theme store
-import { useSeasonStore } from '@/store/seasonStore'; // Import the season store
+import { useThemeStore } from '@/store/themeStore';
+import { useSeasonStore } from '@/store/seasonStore';
 
 // Import Tailwind CSS
 import './assets/tailwind.css';
@@ -13,26 +13,30 @@ import '@/assets/_variables.css';
 import '@/assets/style.css';
 
 const app = createApp(App);
+const pinia = createPinia();
 app.use(router);
 app.use(vuetify);
-app.use(createPinia());
-app.mount('#app');
+app.use(pinia);
 
 // Detect system theme
 const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-// Access the theme store
-const themeStore = useThemeStore();
-// Access the season store and load from localStorage
-const seasonStore = useSeasonStore();
-seasonStore.loadSeasonFromStorage();
+const themeStore = useThemeStore(pinia);
+const seasonStore = useSeasonStore(pinia);
 
-if (prefersDarkScheme.matches) {
-  themeStore.isDarkTheme = true; // Update the store state
-} else {
-  themeStore.isDarkTheme = false; // Update the store state
+async function bootstrap() {
+  await seasonStore.initializeSeasonOptions();
+
+  if (prefersDarkScheme.matches) {
+    themeStore.isDarkTheme = true;
+  } else {
+    themeStore.isDarkTheme = false;
+  }
+
+  prefersDarkScheme.addEventListener('change', (event) => {
+    themeStore.isDarkTheme = event.matches;
+  });
+
+  app.mount('#app');
 }
 
-// Listen for changes in theme preference
-prefersDarkScheme.addEventListener('change', (event) => {
-  themeStore.isDarkTheme = event.matches; // Update the store state
-});
+bootstrap();

--- a/src/pages/DraftPage.vue
+++ b/src/pages/DraftPage.vue
@@ -10,7 +10,7 @@
   </transition>
   <transition name="fade">
     <v-alert
-      v-if="isYourTurn && !isDraftOver"
+      v-if="isYourTurn && !isDraftOver && !isReadOnlyDraft"
       type="success"
       class="fixed m-auto w-full text-center mb-4 z-50"
       closable
@@ -38,6 +38,9 @@
     {{ snackbar.message }}
   </v-snackbar>
   <v-container class="max-w-screen-lg">
+    <v-alert v-if="isReadOnlyDraft" type="info" class="mb-4">
+      Draft is read-only during active season.
+    </v-alert>
     <v-alert
       v-if="loadError && !isLoading"
       type="error"
@@ -167,7 +170,10 @@
               :class="{
                 picked: pickedTeams.includes(team),
                 'cursor-pointer':
-                  currentPickerId === playerName && !pickedTeams.includes(team),
+                  !isReadOnlyDraft &&
+                  currentPickerId === playerName &&
+                  !pickedTeams.includes(team),
+                'read-only': isReadOnlyDraft,
               }"
               @click="selectTeam(team)"
             >
@@ -231,6 +237,7 @@ const route = useRoute();
 const seasonStore = useSeasonStore();
 const playerName = route.params.name;
 const currentPlayer = ref(null);
+const isReadOnlyDraft = computed(() => route.query.mode === 'readonly');
 
 const allPlayersData = ref([]);
 const currentPickerId = ref('');
@@ -410,6 +417,10 @@ async function selectTeam(team) {
   if (!audioReady.value) {
     preloadAudio(); // preload audio on user interaction
   }
+  if (isReadOnlyDraft.value) {
+    showSnackbar('Draft is locked during active season.', 'warning');
+    return;
+  }
   if (
     !currentPlayer.value ||
     currentPlayer.value.id !== currentPickerId.value
@@ -485,6 +496,10 @@ watch(isYourTurn, (newVal) => {
   filter: grayscale(100%);
   opacity: 0.5;
   pointer-events: none;
+}
+.read-only {
+  pointer-events: none;
+  opacity: 0.8;
 }
 .border-success {
   border-color: #4caf50 !important;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import { getSeasonMeta } from '@/services/championServices';
+import { getDraftPlayers, getDraftState } from '@/services/dynamodbService';
+import { useSeasonStore } from '@/store/seasonStore';
 import HomePage from '../pages/HomePage.vue';
 import StandingsPage from '../pages/StandingsPage.vue';
 import AboutPage from '../pages/AboutPage.vue';
@@ -39,6 +42,76 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+});
+
+async function resolveDraftRouteAccess(seasonId) {
+  const seasonMeta = await getSeasonMeta({ season: seasonId });
+  if (seasonMeta?.seasonOver) {
+    return {
+      allowDraftPage: true,
+      allowDraftAdmin: true,
+      readOnly: false,
+    };
+  }
+
+  const [draftState, players] = await Promise.all([
+    getDraftState({ season: seasonId }),
+    getDraftPlayers({ season: seasonId }),
+  ]);
+
+  const noTeamsRemaining =
+    Array.isArray(draftState?.availableTeams) &&
+    draftState.availableTeams.length === 0;
+  const everyPlayerHasTeams =
+    Array.isArray(players) &&
+    players.length > 0 &&
+    players.every(
+      (player) => Array.isArray(player?.teams) && player.teams.length > 0
+    );
+
+  const draftComplete = noTeamsRemaining && everyPlayerHasTeams;
+  return {
+    allowDraftPage: draftComplete,
+    allowDraftAdmin: false,
+    readOnly: draftComplete,
+  };
+}
+
+router.beforeEach(async (to) => {
+  if (!to.path.startsWith('/draft')) {
+    return true;
+  }
+
+  const seasonStore = useSeasonStore();
+  seasonStore.loadSeasonFromStorage();
+  const seasonId = seasonStore.currentSeason || 'season2';
+
+  try {
+    const access = await resolveDraftRouteAccess(seasonId);
+
+    if (to.path === '/draft/admin') {
+      if (!access.allowDraftAdmin) {
+        return { path: '/' };
+      }
+      return true;
+    }
+
+    if (!access.allowDraftPage) {
+      return { path: '/' };
+    }
+
+    if (access.readOnly && to.query.mode !== 'readonly') {
+      return {
+        path: to.path,
+        query: { ...to.query, mode: 'readonly' },
+        replace: true,
+      };
+    }
+    return true;
+  } catch (error) {
+    console.error('[router] Failed to validate draft route access:', error);
+    return { path: '/' };
+  }
 });
 
 export default router;

--- a/src/services/dynamodbService.js
+++ b/src/services/dynamodbService.js
@@ -48,8 +48,8 @@ export async function updateDraftState(patch, options = {}) {
   });
 }
 
-export async function getDraftPlayers() {
-  return getAllPlayers();
+export async function getDraftPlayers(options = {}) {
+  return getAllPlayers(options);
 }
 
 export async function selectTeamForPlayer(playerId, team, options = {}) {

--- a/src/services/seasonService.js
+++ b/src/services/seasonService.js
@@ -1,0 +1,87 @@
+import { apiRequest } from '@/services/apiClient';
+
+function normalizeSeasonId(value) {
+  const normalized = String(value || '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) return null;
+  if (/^season\d+$/.test(normalized)) {
+    return normalized;
+  }
+  const parsed = Number(normalized);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    return `season${parsed}`;
+  }
+  return null;
+}
+
+function toSeasonLabel(seasonId) {
+  const match = String(seasonId || '').match(/^season(\d+)$/);
+  if (!match) return String(seasonId || '');
+  return String(Number(match[1]));
+}
+
+function normalizeSeasonOption(entry) {
+  if (typeof entry === 'string') {
+    const id = normalizeSeasonId(entry);
+    if (!id) return null;
+    return { id, label: toSeasonLabel(id) };
+  }
+  if (!entry || typeof entry !== 'object') return null;
+  const id = normalizeSeasonId(entry.id || entry.value);
+  if (!id) return null;
+  return {
+    id,
+    label: String(entry.label || toSeasonLabel(id)),
+    status: entry.status || null,
+  };
+}
+
+function normalizeSeasonOptionsPayload(payload = {}) {
+  const defaultSeason = normalizeSeasonId(payload.defaultSeason) || 'season2';
+  const options = Array.isArray(payload.seasons)
+    ? payload.seasons.map(normalizeSeasonOption).filter(Boolean)
+    : [];
+
+  const unique = [];
+  const seen = new Set();
+  options.forEach((entry) => {
+    if (seen.has(entry.id)) return;
+    seen.add(entry.id);
+    unique.push(entry);
+  });
+
+  if (!seen.has(defaultSeason)) {
+    unique.push({
+      id: defaultSeason,
+      label: toSeasonLabel(defaultSeason),
+      status: null,
+    });
+  }
+
+  unique.sort((a, b) => {
+    const aNum = Number((a.id.match(/^season(\d+)$/) || [])[1] || 9999);
+    const bNum = Number((b.id.match(/^season(\d+)$/) || [])[1] || 9999);
+    return aNum - bNum;
+  });
+
+  return {
+    defaultSeason,
+    seasons: unique,
+    updatedAt: payload.updatedAt || null,
+  };
+}
+
+export async function getSeasonOptions() {
+  const payload = await apiRequest('/season/options', {
+    retries: 0,
+  });
+  return normalizeSeasonOptionsPayload(payload);
+}
+
+export function getFallbackSeasonOptions() {
+  return normalizeSeasonOptionsPayload({
+    defaultSeason: 'season2',
+    seasons: ['season1', 'season2'],
+  });
+}

--- a/src/store/seasonStore.js
+++ b/src/store/seasonStore.js
@@ -1,35 +1,96 @@
 import { defineStore } from 'pinia';
+import {
+  getFallbackSeasonOptions,
+  getSeasonOptions,
+} from '@/services/seasonService';
 
 export const useSeasonStore = defineStore('season', {
   state: () => ({
-    currentSeason: 'season2', // Default to Season 2 (current season)
+    currentSeason: 'season2',
+    seasonOptions: [
+      { label: '1', value: 'season1' },
+      { label: '2', value: 'season2' },
+    ],
+    seasonOptionsLoaded: false,
   }),
   getters: {
-    playersTableName: (state) => {
-      return state.currentSeason === 'season1' ? 'Players-Season1' : 'Players';
-    },
-    gameRecordsTableName: (state) => {
-      return state.currentSeason === 'season1'
-        ? 'GameRecords-Season1'
-        : 'GameRecords';
-    },
+    playersTableName: () => 'PlayerSeason + PlayerLifetime',
+    gameRecordsTableName: () => 'GameRecordsV2',
     playerImagesPath: (state) => {
       return state.currentSeason === 'season1' ? 'season1' : 'season2';
     },
     seasonDisplayName: (state) => {
-      return state.currentSeason === 'season1' ? 'Season 1' : 'Season 2';
+      const selected = state.seasonOptions.find(
+        (option) => option.value === state.currentSeason
+      );
+      const label = selected?.label || state.currentSeason;
+      return `Season ${label}`;
     },
   },
   actions: {
     setSeason(season) {
       this.currentSeason = season;
-      // Persist to localStorage
       localStorage.setItem('selectedSeason', season);
+    },
+    setSeasonOptions(seasonOptions, defaultSeason) {
+      const normalized = Array.isArray(seasonOptions)
+        ? seasonOptions.filter(
+            (option) => option && option.value && option.label !== undefined
+          )
+        : [];
+
+      this.seasonOptions =
+        normalized.length > 0
+          ? normalized
+          : [
+              { label: '1', value: 'season1' },
+              { label: '2', value: 'season2' },
+            ];
+
+      const validValues = new Set(
+        this.seasonOptions.map((option) => option.value)
+      );
+      const stored = localStorage.getItem('selectedSeason');
+
+      if (stored && validValues.has(stored)) {
+        this.currentSeason = stored;
+      } else if (defaultSeason && validValues.has(defaultSeason)) {
+        this.currentSeason = defaultSeason;
+      } else {
+        this.currentSeason = this.seasonOptions[0]?.value || 'season2';
+      }
+
+      localStorage.setItem('selectedSeason', this.currentSeason);
+      this.seasonOptionsLoaded = true;
     },
     loadSeasonFromStorage() {
       const stored = localStorage.getItem('selectedSeason');
-      if (stored && (stored === 'season1' || stored === 'season2')) {
+      const validValues = new Set(
+        this.seasonOptions.map((option) => option.value)
+      );
+      if (stored && validValues.has(stored)) {
         this.currentSeason = stored;
+      }
+    },
+    async initializeSeasonOptions() {
+      try {
+        const payload = await getSeasonOptions();
+        const seasonOptions = payload.seasons.map((season) => ({
+          label: season.label,
+          value: season.id,
+        }));
+        this.setSeasonOptions(seasonOptions, payload.defaultSeason);
+      } catch (error) {
+        console.warn(
+          '[seasonStore] Failed to load /season/options. Using fallback seasons.',
+          error
+        );
+        const payload = getFallbackSeasonOptions();
+        const seasonOptions = payload.seasons.map((season) => ({
+          label: season.label,
+          value: season.id,
+        }));
+        this.setSeasonOptions(seasonOptions, payload.defaultSeason);
       }
     },
   },

--- a/tests/unit/httpApi.spec.js
+++ b/tests/unit/httpApi.spec.js
@@ -22,6 +22,30 @@ const { db, resetDb, createConditionalError, clone } = vi.hoisted(() => {
   };
 });
 
+function keyFor(key = {}) {
+  const normalized = Object.keys(key)
+    .sort()
+    .reduce((acc, currentKey) => {
+      acc[currentKey] = key[currentKey];
+      return acc;
+    }, {});
+  return JSON.stringify(normalized);
+}
+
+function getKeySchema(tableName, sample = {}) {
+  if (tableName === 'DraftState') return ['draftId'];
+  if (tableName === 'PlayerSeason') return ['seasonId', 'playerId'];
+  if (tableName === 'PlayerLifetime') return ['playerId'];
+  if (tableName === 'GameRecordsV2') return ['seasonId', 'gameId'];
+  if (tableName === 'GameOptions') return ['id'];
+  if ('seasonId' in sample && 'playerId' in sample)
+    return ['seasonId', 'playerId'];
+  if ('seasonId' in sample && 'gameId' in sample) return ['seasonId', 'gameId'];
+  if ('draftId' in sample) return ['draftId'];
+  if ('playerId' in sample) return ['playerId'];
+  return ['id'];
+}
+
 function getTable(tableName) {
   if (!db.tables[tableName]) {
     db.tables[tableName] = {};
@@ -29,13 +53,31 @@ function getTable(tableName) {
   return db.tables[tableName];
 }
 
+function putItem(tableName, item) {
+  const keySchema = getKeySchema(tableName, item);
+  const key = keySchema.reduce((acc, field) => {
+    acc[field] = item[field];
+    return acc;
+  }, {});
+  getTable(tableName)[keyFor(key)] = clone(item);
+}
+
+function getItem(tableName, key) {
+  const keySchema = getKeySchema(tableName, key);
+  const normalizedKey = keySchema.reduce((acc, field) => {
+    acc[field] = key[field];
+    return acc;
+  }, {});
+  return getTable(tableName)[keyFor(normalizedKey)] || null;
+}
+
 global.__awsDocumentClientMock = {
   get(params) {
     return {
       promise: async () => {
-        const table = getTable(params.TableName);
+        const item = getItem(params.TableName, params.Key);
         return {
-          Item: table[params.Key.id] ? clone(table[params.Key.id]) : undefined,
+          Item: item ? clone(item) : undefined,
         };
       },
     };
@@ -43,14 +85,25 @@ global.__awsDocumentClientMock = {
   put(params) {
     return {
       promise: async () => {
-        const table = getTable(params.TableName);
-        if (
-          params.ConditionExpression === 'attribute_not_exists(id)' &&
-          table[params.Item.id]
-        ) {
+        const existing = getItem(params.TableName, params.Item);
+        const condition = params.ConditionExpression || '';
+
+        if (condition.includes('attribute_not_exists') && existing) {
           throw createConditionalError();
         }
-        table[params.Item.id] = clone(params.Item);
+
+        if (condition.includes('attribute_exists(draftId)')) {
+          if (!existing) {
+            throw createConditionalError();
+          }
+          const expectedVersion =
+            params.ExpressionAttributeValues?.[':expectedVersion'];
+          if (Number(existing.version) !== Number(expectedVersion)) {
+            throw createConditionalError();
+          }
+        }
+
+        putItem(params.TableName, params.Item);
         return {};
       },
     };
@@ -58,50 +111,37 @@ global.__awsDocumentClientMock = {
   update(params) {
     return {
       promise: async () => {
-        const table = getTable(params.TableName);
-        const keyId = params.Key.id;
-        const current = table[keyId] ? clone(table[keyId]) : { id: keyId };
-        const names = params.ExpressionAttributeNames || {};
+        const existing = getItem(params.TableName, params.Key);
+        const keySchema = getKeySchema(params.TableName, params.Key);
+        const seeded = keySchema.reduce((acc, field) => {
+          acc[field] = params.Key[field];
+          return acc;
+        }, {});
+        const current = existing ? clone(existing) : seeded;
         const values = params.ExpressionAttributeValues || {};
-
-        if (params.ConditionExpression?.includes('#state.#version')) {
-          const currentVersion = current?.state?.version;
-          const expected = values[':expected'];
-          const zero = values[':zero'];
-          const conditionMet =
-            (currentVersion === undefined && expected === zero) ||
-            currentVersion === expected;
-          if (!conditionMet) {
-            throw createConditionalError();
-          }
-        }
 
         if (params.UpdateExpression?.includes('REMOVE gameID')) {
           delete current.gameID;
         }
 
-        if (params.UpdateExpression?.includes('#state = :state')) {
-          current[names['#state']] = clone(values[':state']);
+        if (params.UpdateExpression?.includes('SET gameID = :gameID')) {
+          current.gameID = values[':gameID'];
+          current.updatedAt = values[':updatedAt'];
         }
-        if (params.UpdateExpression?.includes('#updatedAt = :ts')) {
-          current[names['#updatedAt']] = values[':ts'];
-        }
-        if (params.UpdateExpression?.includes('SET gameID = :g')) {
-          current.gameID = values[':g'];
-          current.updatedAt = values[':ts'];
-        }
+
         if (params.UpdateExpression?.includes('SET teams = :teams')) {
           current.teams = clone(values[':teams']);
-          current.updatedAt = values[':ts'];
+          current.updatedAt = values[':updatedAt'];
         }
 
-        table[keyId] = current;
+        putItem(params.TableName, current);
 
         if (params.ReturnValues === 'UPDATED_NEW') {
-          return { Attributes: { gameID: current.gameID } };
-        }
-        if (params.ReturnValues === 'ALL_NEW') {
-          return { Attributes: clone(current) };
+          return {
+            Attributes: {
+              gameID: current.gameID,
+            },
+          };
         }
 
         return {};
@@ -111,14 +151,28 @@ global.__awsDocumentClientMock = {
   scan(params) {
     return {
       promise: async () => {
-        const table = getTable(params.TableName);
-        return { Items: Object.values(table).map((item) => clone(item)) };
+        const items = Object.values(getTable(params.TableName)).map((item) =>
+          clone(item)
+        );
+        return { Items: items };
       },
     };
   },
-  query() {
+  query(params) {
     return {
-      promise: async () => ({ Items: [] }),
+      promise: async () => {
+        const items = Object.values(getTable(params.TableName)).map((item) =>
+          clone(item)
+        );
+        const seasonId = params.ExpressionAttributeValues?.[':seasonId'];
+        if (seasonId === undefined) {
+          return { Items: items };
+        }
+
+        return {
+          Items: items.filter((item) => item.seasonId === seasonId),
+        };
+      },
     };
   },
 };
@@ -169,31 +223,36 @@ describe('http-api contract behavior', () => {
   });
 
   it('returns champion history sorted and respects limit', async () => {
-    const table = getTable('GameRecords');
-    table[1] = {
-      id: 1,
+    putItem('GameRecordsV2', {
+      seasonId: 'season2',
+      gameId: '1',
+      id: '1',
       wTeam: 'BOS',
       wScore: 4,
       lTeam: 'TOR',
       lScore: 2,
       savedAt: '2026-01-01T00:00:00.000Z',
-    };
-    table[2] = {
-      id: 2,
+    });
+    putItem('GameRecordsV2', {
+      seasonId: 'season2',
+      gameId: '2',
+      id: '2',
       wTeam: 'DAL',
       wScore: 3,
       lTeam: 'COL',
       lScore: 1,
       savedAt: '2026-02-01T00:00:00.000Z',
-    };
-    table[3] = {
-      id: 3,
+    });
+    putItem('GameRecordsV2', {
+      seasonId: 'season2',
+      gameId: '3',
+      id: '3',
       wTeam: 'VAN',
       wScore: 5,
       lTeam: 'SEA',
       lScore: 4,
       savedAt: '2026-03-01T00:00:00.000Z',
-    };
+    });
 
     const result = await invoke('/champion/history', 'GET', {
       queryStringParameters: { limit: '2' },
@@ -216,19 +275,16 @@ describe('http-api contract behavior', () => {
   });
 
   it('rejects draft patch when version is missing', async () => {
-    const table = getTable('GameOptions');
-    table.draftState = {
-      id: 'draftState',
-      state: {
-        draftStarted: true,
-        pickOrder: [1, 2],
-        currentPicker: 1,
-        currentPickNumber: 1,
-        availableTeams: ['BOS', 'TOR'],
-        version: 2,
-      },
+    putItem('DraftState', {
+      draftId: 'season2',
+      draftStarted: true,
+      pickOrder: ['1', '2'],
+      currentPicker: '1',
+      currentPickNumber: 1,
+      availableTeams: ['BOS', 'TOR'],
+      version: 2,
       updatedAt: '2026-03-01T00:00:00.000Z',
-    };
+    });
 
     const result = await invoke('/draft/state', 'PATCH', {
       body: {
@@ -242,19 +298,16 @@ describe('http-api contract behavior', () => {
 
   it('enforces auth on protected routes when admin token is configured', async () => {
     process.env.ADMIN_API_TOKEN = 'super-secret';
-    const table = getTable('GameOptions');
-    table.draftState = {
-      id: 'draftState',
-      state: {
-        draftStarted: true,
-        pickOrder: [1, 2],
-        currentPicker: 1,
-        currentPickNumber: 1,
-        availableTeams: ['BOS', 'TOR'],
-        version: 0,
-      },
+    putItem('DraftState', {
+      draftId: 'season2',
+      draftStarted: true,
+      pickOrder: ['1', '2'],
+      currentPicker: '1',
+      currentPickNumber: 1,
+      availableTeams: ['BOS', 'TOR'],
+      version: 0,
       updatedAt: '2026-03-01T00:00:00.000Z',
-    };
+    });
 
     const unauthorized = await invoke('/draft/state', 'PATCH', {
       body: {
@@ -275,23 +328,20 @@ describe('http-api contract behavior', () => {
       },
     });
     expect(authorized.statusCode).toBe(200);
-    expect(authorized.json.currentPicker).toBe(2);
+    expect(authorized.json.currentPicker).toBe('2');
   });
 
   it('returns 409 with current state for stale draft updates', async () => {
-    const table = getTable('GameOptions');
-    table.draftState = {
-      id: 'draftState',
-      state: {
-        draftStarted: true,
-        pickOrder: [1, 2],
-        currentPicker: 1,
-        currentPickNumber: 1,
-        availableTeams: ['BOS', 'TOR'],
-        version: 4,
-      },
+    putItem('DraftState', {
+      draftId: 'season2',
+      draftStarted: true,
+      pickOrder: ['1', '2'],
+      currentPicker: '1',
+      currentPickNumber: 1,
+      availableTeams: ['BOS', 'TOR'],
+      version: 4,
       updatedAt: '2026-03-01T00:00:00.000Z',
-    };
+    });
 
     const result = await invoke('/draft/state', 'PATCH', {
       body: {
@@ -302,23 +352,20 @@ describe('http-api contract behavior', () => {
 
     expect(result.statusCode).toBe(409);
     expect(result.json.currentVersion).toBe(4);
-    expect(result.json.currentState.currentPicker).toBe(1);
+    expect(result.json.currentState.currentPicker).toBe('1');
   });
 
   it('accepts in-order draft updates and increments version', async () => {
-    const table = getTable('GameOptions');
-    table.draftState = {
-      id: 'draftState',
-      state: {
-        draftStarted: true,
-        pickOrder: [1, 2],
-        currentPicker: 1,
-        currentPickNumber: 1,
-        availableTeams: ['BOS', 'TOR'],
-        version: 1,
-      },
+    putItem('DraftState', {
+      draftId: 'season2',
+      draftStarted: true,
+      pickOrder: ['1', '2'],
+      currentPicker: '1',
+      currentPickNumber: 1,
+      availableTeams: ['BOS', 'TOR'],
+      version: 1,
       updatedAt: '2026-03-01T00:00:00.000Z',
-    };
+    });
 
     const result = await invoke('/draft/state', 'PATCH', {
       body: {
@@ -329,7 +376,7 @@ describe('http-api contract behavior', () => {
     });
 
     expect(result.statusCode).toBe(200);
-    expect(result.json.currentPicker).toBe(2);
+    expect(result.json.currentPicker).toBe('2');
     expect(result.json.version).toBe(2);
   });
 });


### PR DESCRIPTION
## Merge only after season is over

This PR contains the offseason-only big-bang multi-season refactor. Do **not** merge in-season.

## What changed

### 1) Backend data model cutover
- HTTP API now reads/writes only:
  - `PlayerLifetime`
  - `PlayerSeason`
  - `GameRecordsV2`
  - `DraftState` (`draftId=seasonId`)
- Added/kept season catalog endpoint:
  - `GET /season/options`
- `GET /players` and `GET /players/:name` now merge season + lifetime data into existing response shape.
- `GET /game-records` and `GET /champion/history` are season-partitioned via `seasonId`.
- Kept draft/team in-season mutation lock behavior (`409`) during active season.

### 2) Checker Lambda cutover
- `lambdas/check-game` now:
  - writes finalized game records to `GameRecordsV2` (`seasonId + gameId`)
  - increments `titleDefenses` in `PlayerSeason`
  - increments `totalDefenses` in `PlayerLifetime`

### 3) Frontend season and draft behavior
- Season selector options are now API-driven from `GET /season/options`.
- Bootstraps season options before app mount, preserving selected-season persistence.
- Draft route gating updated:
  - `/draft/admin` only allowed offseason (`seasonOver=true`)
  - `/draft/:name?` allowed in active season only when draft is complete, as read-only snapshot.

### 4) Offseason migration + runbook
- Added migration script:
  - `scripts/aws/offseason-migrate-season-data.sh`
- Script snapshots legacy tables, backfills new tables, upserts season catalog, and optionally applies Lambda env cutover.
- Updated docs:
  - `docs/season-data-runbook.md`
  - `README.md`
- Added AI project planning artifacts:
  - `ai/project/offseason-multi-season-refactor/SPEC.md`
  - `ai/project/offseason-multi-season-refactor/BACKLOG.md`

## Why
- Removes manual yearly table cloning as the core runtime pattern.
- Normalizes season handling into explicit season partition keys.
- Preserves lifetime player stats (`championships`, `totalDefenses`) while keeping season-only stats (`titleDefenses`) scoped correctly.
- Provides a single documented offseason migration path with rollback support.

## Verification
- `npm run test:unit`
- `npm run lint`

## Merge gate checklist
- [ ] `GET /season/meta?season=season2` returns `seasonOver=true`
- [ ] Date is on/after **April 17, 2026**
- [ ] Pre-draft offseason window confirmed by operator
