### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/ci-workflow-fixes-patch.md
+++ b/.changeset/ci-workflow-fixes-patch.md
@@ -1,5 +1,0 @@
----
-"in-season-stanley-cup": patch
----
-
-Fix GitHub Actions workflow stability by correcting issue release-tag workflow YAML parsing and preventing release-versioning hard failures when repository PR creation is restricted for `GITHUB_TOKEN`.

--- a/.changeset/player-profile-trends-minor.md
+++ b/.changeset/player-profile-trends-minor.md
@@ -1,5 +1,0 @@
----
-"in-season-stanley-cup": minor
----
-
-Add player profile trend snapshot analytics and improve profile page layout consistency/mobile responsiveness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.0
+
+### Minor Changes
+
+- b707db9: Add player profile trend snapshot analytics and improve profile page layout consistency/mobile responsiveness.
+
+### Patch Changes
+
+- 1ed8879: Fix GitHub Actions workflow stability by correcting issue release-tag workflow YAML parsing and preventing release-versioning hard failures when repository PR creation is restricted for `GITHUB_TOKEN`.
+
 All notable changes to this project are tracked in this file.
 
 The format follows Keep a Changelog and Semantic Versioning.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "in-season-stanley-cup",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
Automated Changesets release update.

Includes:
- version bump from `2.0.0` to `2.1.0`
- changelog updates
- removal of consumed changeset files

This PR exists because repository settings currently block Actions from creating PRs with `GITHUB_TOKEN`.