### PR TITLE
chore(ci): auto-merge changeset release PRs

### DIFF
--- a/.changeset/auto-merge-release-pr-patch.md
+++ b/.changeset/auto-merge-release-pr-patch.md
@@ -1,0 +1,5 @@
+---
+"in-season-stanley-cup": patch
+---
+
+Add GitHub Actions automation to auto-enable merge for `changeset-release/main` release PRs so version bump PRs merge automatically after required checks pass.

--- a/.github/workflows/auto-merge-release-pr.yml
+++ b/.github/workflows/auto-merge-release-pr.yml
@@ -1,0 +1,55 @@
+name: Auto-Merge Release PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: |
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref == 'changeset-release/main' &&
+      github.event.pull_request.title == 'chore(release): version packages' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            try {
+              await github.graphql(
+                `mutation EnableAutoMerge($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(
+                    input: {
+                      pullRequestId: $pullRequestId
+                      mergeMethod: MERGE
+                    }
+                  ) {
+                    pullRequest {
+                      number
+                    }
+                  }
+                }`,
+                { pullRequestId: pr.node_id }
+              );
+
+              core.info(`Enabled auto-merge for PR #${pr.number}.`);
+            } catch (error) {
+              const message = String(error?.message || "");
+              if (message.includes("Auto merge is already enabled")) {
+                core.info(`Auto-merge already enabled for PR #${pr.number}.`);
+                return;
+              }
+              throw error;
+            }


### PR DESCRIPTION
## Summary
Make release versioning fully seamless by auto-merging the generated release PR (`changeset-release/main`) once required checks pass.

## Changes
- Added workflow: `.github/workflows/auto-merge-release-pr.yml`
  - Trigger: `pull_request_target` events on PR updates
  - Scope-limited to PRs where:
    - base branch is `main`
    - head branch is `changeset-release/main`
    - title is `chore(release): version packages`
    - PR is not draft
  - Action: enables GitHub auto-merge using merge commit mode.
- Added changeset entry for this CI/process update.

## Repository Setting Updated
To support this flow, repository setting `allow_auto_merge` has been enabled (true).

## Resulting Flow
1. Merge feature PR with changeset.
2. `Release Versioning` workflow updates/creates release PR.
3. New auto-merge workflow enables auto-merge on that PR.
4. Release PR merges automatically after required checks are green.
